### PR TITLE
chore: clarify user input convention for multiorbital non-reciprocal models

### DIFF
--- a/Paclet/Documentation/English/ReferencePages/Symbols/NonReciprocalAbelianBlochHamiltonian.nb
+++ b/Paclet/Documentation/English/ReferencePages/Symbols/NonReciprocalAbelianBlochHamiltonian.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[    144163,       3477]
-NotebookOptionsPosition[    129055,       3155]
-NotebookOutlinePosition[    129862,       3181]
-CellTagsIndexPosition[    129781,       3176]
+NotebookDataLength[    144269,       3479]
+NotebookOptionsPosition[    129160,       3157]
+NotebookOutlinePosition[    129967,       3183]
+CellTagsIndexPosition[    129886,       3178]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -283,14 +283,15 @@ Cell[BoxData[
         {
          RowBox[{
           SubscriptBox["b", "i"], "\[Rule]", 
-          SubscriptBox["b", "j"]}], 
+          SubscriptBox["a", "j"]}], 
          RowBox[{
           SubscriptBox["b", "i"], "\[Rule]", 
           SubscriptBox["b", "j"]}]}
        }], ")"}], "&"}]}], ";"}], " "}]], "Notes",
  CellChangeTimes->{{3.9594190921442356`*^9, 3.9594191869209785`*^9}, {
    3.9594199305607395`*^9, 3.959419942131056*^9}, 3.9594199844307747`*^9, {
-   3.959420111086876*^9, 3.9594201114812164`*^9}, 3.959420152732893*^9},
+   3.959420111086876*^9, 3.9594201114812164`*^9}, 3.959420152732893*^9, {
+   3.959660448653137*^9, 3.9596604488049374`*^9}},
  CellID->207376718,ExpressionUUID->"fe1ae727-78d3-fa45-9ae6-a294808aa9bd"],
 
 Cell[TextData[Cell[BoxData[
@@ -308,7 +309,7 @@ Cell[TextData[Cell[BoxData[
        {
         RowBox[{
          SubscriptBox["b", "i"], "\[LeftArrow]", 
-         SubscriptBox["b", "j"]}], 
+         SubscriptBox["a", "j"]}], 
         RowBox[{
          SubscriptBox["b", "i"], "\[LeftArrow]", 
          SubscriptBox["b", "j"]}]}
@@ -317,7 +318,8 @@ Cell[TextData[Cell[BoxData[
   3.9594199305607395`*^9, 
   3.959419942131056*^9}},ExpressionUUID->"2850798a-6068-5a4f-9261-\
 c718489a9cf0"]], "Notes",
- CellChangeTimes->{{3.959420522251034*^9, 3.9594205393492985`*^9}},
+ CellChangeTimes->{{3.959420522251034*^9, 3.9594205393492985`*^9}, {
+  3.9596604557784824`*^9, 3.9596604569850826`*^9}},
  CellID->396819643,ExpressionUUID->"cdf84976-5e92-3a49-b5fa-88dc4904df87"],
 
 Cell["The following options can be given:", "Notes",
@@ -557,10 +559,10 @@ AbelianBlochHamiltonianExpression"]], "InlineSeeAlsoFunction",
     "40a5967c-b2d7-4ad4-bb67-87cb6c247423"], 
    DynamicModuleBox[{$CellContext`nbobj$$ = NotebookObject[
     "ca524783-33ba-4436-a7c7-e9b68abdb844", 
-     "7c289219-9f2e-6046-ab73-6e12af829af9"], $CellContext`cellobj$$ = 
+     "d439944e-8a1d-8b4e-8a6f-7eb67b9c6a63"], $CellContext`cellobj$$ = 
     CellObject[
     "f192ff71-19a1-4a57-b3cc-520a4f08fea8", 
-     "37d6b5d7-23f1-b44f-9000-fdd70011d409"]}, 
+     "767e0a99-20d6-c741-8c4b-70322bafb557"]}, 
     TemplateBox[{
       GraphicsBox[{{
          Thickness[0.06], 
@@ -3168,14 +3170,14 @@ ExpressionUUID->"ca524783-33ba-4436-a7c7-e9b68abdb844"
 (*CellTagsOutline
 CellTagsIndex->{
  "ExtendedExamples"->{
-  Cell[44581, 1184, 485, 13, 62, "ExtendedExamplesSection",ExpressionUUID->"67ec221c-caf6-4173-ad73-9d17ddeabdd0",
+  Cell[44686, 1186, 485, 13, 62, "ExtendedExamplesSection",ExpressionUUID->"67ec221c-caf6-4173-ad73-9d17ddeabdd0",
    CellTags->"ExtendedExamples",
    CellID->9214842]}
  }
 *)
 (*CellTagsIndex
 CellTagsIndex->{
- {"ExtendedExamples", 129588, 3169}
+ {"ExtendedExamples", 129693, 3171}
  }
 *)
 (*NotebookFileOutline
@@ -3195,287 +3197,287 @@ Cell[7028, 189, 1211, 29, 73, "Notes",ExpressionUUID->"48d2991f-d268-794b-a96d-3
  CellID->157982633],
 Cell[8242, 220, 2105, 47, 172, "Notes",ExpressionUUID->"4b29621e-e5a1-014b-ac6b-2794c9594036",
  CellID->311370265],
-Cell[10350, 269, 882, 24, 45, "Notes",ExpressionUUID->"fe1ae727-78d3-fa45-9ae6-a294808aa9bd",
+Cell[10350, 269, 934, 25, 45, "Notes",ExpressionUUID->"fe1ae727-78d3-fa45-9ae6-a294808aa9bd",
  CellID->207376718],
-Cell[11235, 295, 910, 25, 45, "Notes",ExpressionUUID->"cdf84976-5e92-3a49-b5fa-88dc4904df87",
+Cell[11287, 296, 963, 26, 45, "Notes",ExpressionUUID->"cdf84976-5e92-3a49-b5fa-88dc4904df87",
  CellID->396819643],
-Cell[12148, 322, 223, 3, 28, "Notes",ExpressionUUID->"916d2e20-f426-4271-9d7c-a98609af83a2",
+Cell[12253, 324, 223, 3, 28, "Notes",ExpressionUUID->"916d2e20-f426-4271-9d7c-a98609af83a2",
  CellID->122405462],
-Cell[12374, 327, 2245, 48, 176, "3ColumnTableMod",ExpressionUUID->"d8fef008-55a1-4e3c-9331-a244f4fc957d",
+Cell[12479, 329, 2245, 48, 176, "3ColumnTableMod",ExpressionUUID->"d8fef008-55a1-4e3c-9331-a244f4fc957d",
  CellID->45544999],
-Cell[14622, 377, 494, 12, 28, "Notes",ExpressionUUID->"06107a60-30ae-4fb1-b3dc-d37ff9fca811",
+Cell[14727, 379, 494, 12, 28, "Notes",ExpressionUUID->"06107a60-30ae-4fb1-b3dc-d37ff9fca811",
  CellID->612325770],
-Cell[15119, 391, 1233, 28, 70, "Notes",ExpressionUUID->"4ee2233a-ed55-446d-b19b-d328dec0fa7d",
+Cell[15224, 393, 1233, 28, 70, "Notes",ExpressionUUID->"4ee2233a-ed55-446d-b19b-d328dec0fa7d",
  CellID->346090343]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[16389, 424, 435, 12, 43, "TechNotesSection",ExpressionUUID->"0fea9c94-dcc9-4460-b773-0032ab8ec549",
+Cell[16494, 426, 435, 12, 43, "TechNotesSection",ExpressionUUID->"0fea9c94-dcc9-4460-b773-0032ab8ec549",
  CellID->995312194],
-Cell[16827, 438, 265, 6, 19, "Tutorials",ExpressionUUID->"1928c8e7-a68c-46a0-8cba-0ffff1419b9e",
+Cell[16932, 440, 265, 6, 19, "Tutorials",ExpressionUUID->"1928c8e7-a68c-46a0-8cba-0ffff1419b9e",
  CellID->151400]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[17129, 449, 472, 13, 42, "RelatedLinksSection",ExpressionUUID->"fecb14cf-25fa-4a0c-9894-8ca8438f0be1",
+Cell[17234, 451, 472, 13, 42, "RelatedLinksSection",ExpressionUUID->"fecb14cf-25fa-4a0c-9894-8ca8438f0be1",
  CellID->202509145],
-Cell[17604, 464, 103, 1, 19, "RelatedLinks",ExpressionUUID->"79cdcc1a-2b16-4dc9-9e2d-fc7a3173b09d",
+Cell[17709, 466, 103, 1, 19, "RelatedLinks",ExpressionUUID->"79cdcc1a-2b16-4dc9-9e2d-fc7a3173b09d",
  CellID->144199850]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[17744, 470, 458, 13, 42, "SeeAlsoSection",ExpressionUUID->"050b63cf-bf1c-4662-94e7-626aec5d6b33",
+Cell[17849, 472, 458, 13, 42, "SeeAlsoSection",ExpressionUUID->"050b63cf-bf1c-4662-94e7-626aec5d6b33",
  CellID->223461721],
-Cell[18205, 485, 4479, 107, 56, "SeeAlso",ExpressionUUID->"dbc05f00-cfba-473e-bc6d-ca3adf85f088",
+Cell[18310, 487, 4479, 107, 56, "SeeAlso",ExpressionUUID->"dbc05f00-cfba-473e-bc6d-ca3adf85f088",
  CellID->381155944]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[22721, 597, 182, 2, 41, "MoreAboutSection",ExpressionUUID->"628c56fb-2a64-454a-afda-0c72e8b98f07",
+Cell[22826, 599, 182, 2, 41, "MoreAboutSection",ExpressionUUID->"628c56fb-2a64-454a-afda-0c72e8b98f07",
  CellID->31221473],
-Cell[22906, 601, 281, 6, 19, "MoreAbout",ExpressionUUID->"f716947c-4c12-47a4-9cff-f2a24ce82555",
+Cell[23011, 603, 281, 6, 19, "MoreAbout",ExpressionUUID->"f716947c-4c12-47a4-9cff-f2a24ce82555",
  CellID->542581366]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[23224, 612, 530, 14, 75, "ExamplesInitializationSection",ExpressionUUID->"d27dce01-6ac7-4a45-a9d6-0701f911e181",
+Cell[23329, 614, 530, 14, 75, "ExamplesInitializationSection",ExpressionUUID->"d27dce01-6ac7-4a45-a9d6-0701f911e181",
  CellID->428868112],
-Cell[23757, 628, 306, 5, 49, "ExampleInitialization",ExpressionUUID->"b9b2fab4-94b0-40ca-9b3a-2f0308baac5d",
+Cell[23862, 630, 306, 5, 49, "ExampleInitialization",ExpressionUUID->"b9b2fab4-94b0-40ca-9b3a-2f0308baac5d",
  CellID->127019986]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[24100, 638, 442, 12, 76, "PrimaryExamplesSection",ExpressionUUID->"d2f8cf66-026c-48d5-a784-375f28f06a2d",
+Cell[24205, 640, 442, 12, 76, "PrimaryExamplesSection",ExpressionUUID->"d2f8cf66-026c-48d5-a784-375f28f06a2d",
  CellID->287190428],
-Cell[24545, 652, 1033, 17, 78, "ExampleText",ExpressionUUID->"ebb1feb3-0056-4f70-a821-cb75db877955",
+Cell[24650, 654, 1033, 17, 78, "ExampleText",ExpressionUUID->"ebb1feb3-0056-4f70-a821-cb75db877955",
  CellID->82755364],
 Cell[CellGroupData[{
-Cell[25603, 673, 879, 17, 46, "Input",ExpressionUUID->"1801ac2d-56d7-4398-bb12-0df44e788296",
+Cell[25708, 675, 879, 17, 46, "Input",ExpressionUUID->"1801ac2d-56d7-4398-bb12-0df44e788296",
  CellID->2282893],
-Cell[26485, 692, 1250, 32, 29, "Output",ExpressionUUID->"d85b87b9-5ea5-e142-aa96-c5defb7f74a6",
+Cell[26590, 694, 1250, 32, 29, "Output",ExpressionUUID->"d85b87b9-5ea5-e142-aa96-c5defb7f74a6",
  CellID->358951349]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[27772, 729, 242, 5, 18, "ExampleDelimiter",ExpressionUUID->"922de4a1-c33d-4c53-8420-c637e7f021b3",
+Cell[27877, 731, 242, 5, 18, "ExampleDelimiter",ExpressionUUID->"922de4a1-c33d-4c53-8420-c637e7f021b3",
  CellID->359821871],
-Cell[28017, 736, 286, 4, 25, "ExampleText",ExpressionUUID->"d5d6071a-bed5-46eb-8714-d433cf53be67",
+Cell[28122, 738, 286, 4, 25, "ExampleText",ExpressionUUID->"d5d6071a-bed5-46eb-8714-d433cf53be67",
  CellID->36408547],
 Cell[CellGroupData[{
-Cell[28328, 744, 877, 18, 46, "Input",ExpressionUUID->"3866cf54-8397-470a-83a7-afd78dfcc355",
+Cell[28433, 746, 877, 18, 46, "Input",ExpressionUUID->"3866cf54-8397-470a-83a7-afd78dfcc355",
  CellID->633400500],
-Cell[29208, 764, 1518, 41, 50, "Output",ExpressionUUID->"200b00c8-9201-854c-8f51-7bbc82880d34",
+Cell[29313, 766, 1518, 41, 50, "Output",ExpressionUUID->"200b00c8-9201-854c-8f51-7bbc82880d34",
  CellID->597007231]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[30775, 811, 242, 5, 18, "ExampleDelimiter",ExpressionUUID->"91af1e5a-0ac3-4065-ada3-09c2fcae8951",
+Cell[30880, 813, 242, 5, 18, "ExampleDelimiter",ExpressionUUID->"91af1e5a-0ac3-4065-ada3-09c2fcae8951",
  CellID->677196106],
-Cell[31020, 818, 1465, 30, 78, "ExampleText",ExpressionUUID->"ec5d7117-2c96-4cd7-8c70-8feb237d9c1a",
+Cell[31125, 820, 1465, 30, 78, "ExampleText",ExpressionUUID->"ec5d7117-2c96-4cd7-8c70-8feb237d9c1a",
  CellID->680708440],
 Cell[CellGroupData[{
-Cell[32510, 852, 5169, 145, 340, "Input",ExpressionUUID->"85e83bbc-1b5b-4ac6-911c-21ee445d4a06",
+Cell[32615, 854, 5169, 145, 340, "Input",ExpressionUUID->"85e83bbc-1b5b-4ac6-911c-21ee445d4a06",
  CellID->262417576],
-Cell[37682, 999, 1425, 38, 50, "Output",ExpressionUUID->"b1c315d3-d6ca-9e46-a19e-45e561f5a488",
+Cell[37787, 1001, 1425, 38, 50, "Output",ExpressionUUID->"b1c315d3-d6ca-9e46-a19e-45e561f5a488",
  CellID->238453336]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[39156, 1043, 242, 5, 18, "ExampleDelimiter",ExpressionUUID->"91af2a9a-8d2e-4cc0-9108-b1a6077fc751",
+Cell[39261, 1045, 242, 5, 18, "ExampleDelimiter",ExpressionUUID->"91af2a9a-8d2e-4cc0-9108-b1a6077fc751",
  CellID->228953716],
-Cell[39401, 1050, 1231, 24, 60, "ExampleText",ExpressionUUID->"fcdd41cc-dab8-4085-956b-4fbaead769ff",
+Cell[39506, 1052, 1231, 24, 60, "ExampleText",ExpressionUUID->"fcdd41cc-dab8-4085-956b-4fbaead769ff",
  CellID->16699796],
 Cell[CellGroupData[{
-Cell[40657, 1078, 1576, 40, 174, "Input",ExpressionUUID->"4f1af21c-17c3-43e9-bcd5-c3315c7f5030",
+Cell[40762, 1080, 1576, 40, 174, "Input",ExpressionUUID->"4f1af21c-17c3-43e9-bcd5-c3315c7f5030",
  CellID->78835713],
-Cell[42236, 1120, 2284, 57, 51, "Output",ExpressionUUID->"a350b281-9026-a242-a927-5a1487fff681",
+Cell[42341, 1122, 2284, 57, 51, "Output",ExpressionUUID->"a350b281-9026-a242-a927-5a1487fff681",
  CellID->316316822]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[44581, 1184, 485, 13, 62, "ExtendedExamplesSection",ExpressionUUID->"67ec221c-caf6-4173-ad73-9d17ddeabdd0",
+Cell[44686, 1186, 485, 13, 62, "ExtendedExamplesSection",ExpressionUUID->"67ec221c-caf6-4173-ad73-9d17ddeabdd0",
  CellTags->"ExtendedExamples",
  CellID->9214842],
 Cell[CellGroupData[{
-Cell[45091, 1201, 241, 5, 35, "ExampleSection",ExpressionUUID->"7926246e-3782-40ac-be88-4537478d26ce",
+Cell[45196, 1203, 241, 5, 35, "ExampleSection",ExpressionUUID->"7926246e-3782-40ac-be88-4537478d26ce",
  CellID->403151183],
 Cell[CellGroupData[{
-Cell[45357, 1210, 182, 2, 25, "ExampleSubsection",ExpressionUUID->"95a98044-a233-4544-9891-89bb53f5a862",
+Cell[45462, 1212, 182, 2, 25, "ExampleSubsection",ExpressionUUID->"95a98044-a233-4544-9891-89bb53f5a862",
  CellID->198501545],
-Cell[45542, 1214, 327, 6, 43, "ExampleText",ExpressionUUID->"57b954c0-b7e2-4f82-aadb-289efe4b7cba",
+Cell[45647, 1216, 327, 6, 43, "ExampleText",ExpressionUUID->"57b954c0-b7e2-4f82-aadb-289efe4b7cba",
  CellID->293180495],
-Cell[45872, 1222, 578, 14, 46, "Input",ExpressionUUID->"89618398-f380-475c-b7e4-e054099d4d43",
+Cell[45977, 1224, 578, 14, 46, "Input",ExpressionUUID->"89618398-f380-475c-b7e4-e054099d4d43",
  CellID->407621152],
 Cell[CellGroupData[{
-Cell[46475, 1240, 454, 10, 27, "Input",ExpressionUUID->"6caac9fb-623b-44e4-a9f7-b8e4a66a4a73",
+Cell[46580, 1242, 454, 10, 27, "Input",ExpressionUUID->"6caac9fb-623b-44e4-a9f7-b8e4a66a4a73",
  CellID->244028921],
-Cell[46932, 1252, 474, 10, 26, "Output",ExpressionUUID->"1eaf42c8-938e-6640-8167-cfe868768b18",
+Cell[47037, 1254, 474, 10, 26, "Output",ExpressionUUID->"1eaf42c8-938e-6640-8167-cfe868768b18",
  CellID->389831821]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[47443, 1267, 636, 14, 46, "Input",ExpressionUUID->"7868a0e3-097b-4ce5-9a31-85049d14dd19",
+Cell[47548, 1269, 636, 14, 46, "Input",ExpressionUUID->"7868a0e3-097b-4ce5-9a31-85049d14dd19",
  CellID->197552022],
-Cell[48082, 1283, 2017, 66, 69, "Output",ExpressionUUID->"e3ef61d9-e7d6-dc4d-a6e9-32362d143f61",
+Cell[48187, 1285, 2017, 66, 69, "Output",ExpressionUUID->"e3ef61d9-e7d6-dc4d-a6e9-32362d143f61",
  CellID->484414763]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[50136, 1354, 737, 14, 46, "Input",ExpressionUUID->"a9959ce2-ba04-304e-99f7-ae75042c092e",
+Cell[50241, 1356, 737, 14, 46, "Input",ExpressionUUID->"a9959ce2-ba04-304e-99f7-ae75042c092e",
  CellID->156019331],
-Cell[50876, 1370, 1938, 62, 69, "Output",ExpressionUUID->"399a46f8-6eba-5747-964c-a136b103decd",
+Cell[50981, 1372, 1938, 62, 69, "Output",ExpressionUUID->"399a46f8-6eba-5747-964c-a136b103decd",
  CellID->288153693]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[52851, 1437, 671, 12, 46, "Input",ExpressionUUID->"e5e8ae42-115d-dd4c-8d2e-c7b0d9386bf0",
+Cell[52956, 1439, 671, 12, 46, "Input",ExpressionUUID->"e5e8ae42-115d-dd4c-8d2e-c7b0d9386bf0",
  CellID->657327319],
-Cell[53525, 1451, 3869, 102, 118, "Output",ExpressionUUID->"fdb9dbd0-c952-5d42-93d1-ea143256c897",
+Cell[53630, 1453, 3869, 102, 118, "Output",ExpressionUUID->"fdb9dbd0-c952-5d42-93d1-ea143256c897",
  CellID->121264892]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
-Cell[57433, 1558, 264, 5, 35, "ExampleSection",ExpressionUUID->"cdf3a0a8-61a8-4706-bba7-0936769630ac",
+Cell[57538, 1560, 264, 5, 35, "ExampleSection",ExpressionUUID->"cdf3a0a8-61a8-4706-bba7-0936769630ac",
  CellID->169069801],
 Cell[CellGroupData[{
-Cell[57722, 1567, 242, 5, 21, "ExampleSection",ExpressionUUID->"e8c7c6f4-434b-4367-8a6b-04cfe96eae91",
+Cell[57827, 1569, 242, 5, 21, "ExampleSection",ExpressionUUID->"e8c7c6f4-434b-4367-8a6b-04cfe96eae91",
  CellID->26616468],
 Cell[CellGroupData[{
-Cell[57989, 1576, 249, 5, 25, "ExampleSubsection",ExpressionUUID->"462d4f13-976b-4dd6-a5ee-020fb98a89d1",
+Cell[58094, 1578, 249, 5, 25, "ExampleSubsection",ExpressionUUID->"462d4f13-976b-4dd6-a5ee-020fb98a89d1",
  CellID->121447399],
-Cell[58241, 1583, 270, 5, 25, "ExampleText",ExpressionUUID->"6b353371-c9fb-4414-a3d4-34d156e3273b",
+Cell[58346, 1585, 270, 5, 25, "ExampleText",ExpressionUUID->"6b353371-c9fb-4414-a3d4-34d156e3273b",
  CellID->308716727],
 Cell[CellGroupData[{
-Cell[58536, 1592, 719, 16, 66, "Input",ExpressionUUID->"0330aad9-4cc1-48d7-b9ab-3b14d89c1a63",
+Cell[58641, 1594, 719, 16, 66, "Input",ExpressionUUID->"0330aad9-4cc1-48d7-b9ab-3b14d89c1a63",
  CellID->752120511],
-Cell[59258, 1610, 18824, 367, 54, "Output",ExpressionUUID->"2faa51d9-4c0b-4546-81c7-e4ebd8ec61d1",
+Cell[59363, 1612, 18824, 367, 54, "Output",ExpressionUUID->"2faa51d9-4c0b-4546-81c7-e4ebd8ec61d1",
  CellID->104387430]
 }, Open  ]],
-Cell[78097, 1980, 194, 2, 25, "ExampleText",ExpressionUUID->"dc5f0357-caca-4016-a189-488315e88afd",
+Cell[78202, 1982, 194, 2, 25, "ExampleText",ExpressionUUID->"dc5f0357-caca-4016-a189-488315e88afd",
  CellID->614277478],
 Cell[CellGroupData[{
-Cell[78316, 1986, 333, 8, 27, "Input",ExpressionUUID->"174c5153-60a6-4cda-904a-2dfdb3f26a24",
+Cell[78421, 1988, 333, 8, 27, "Input",ExpressionUUID->"174c5153-60a6-4cda-904a-2dfdb3f26a24",
  CellID->61126152],
-Cell[78652, 1996, 327, 7, 26, "Output",ExpressionUUID->"db28bc47-c84b-44b1-8241-2ca3598aa2af",
+Cell[78757, 1998, 327, 7, 26, "Output",ExpressionUUID->"db28bc47-c84b-44b1-8241-2ca3598aa2af",
  CellID->1456555431]
 }, Open  ]],
-Cell[78994, 2006, 310, 6, 43, "ExampleText",ExpressionUUID->"1b0a8ce4-b0eb-4787-91ad-507a428ac76e",
+Cell[79099, 2008, 310, 6, 43, "ExampleText",ExpressionUUID->"1b0a8ce4-b0eb-4787-91ad-507a428ac76e",
  CellID->443568370],
 Cell[CellGroupData[{
-Cell[79329, 2016, 331, 8, 27, "Input",ExpressionUUID->"a14cd146-f823-4bcb-af45-3132c230598e",
+Cell[79434, 2018, 331, 8, 27, "Input",ExpressionUUID->"a14cd146-f823-4bcb-af45-3132c230598e",
  CellID->194865256],
-Cell[79663, 2026, 487, 9, 22, "Message",ExpressionUUID->"796dd53d-0d66-4653-bce0-2bf5d2ed1f92",
+Cell[79768, 2028, 487, 9, 22, "Message",ExpressionUUID->"796dd53d-0d66-4653-bce0-2bf5d2ed1f92",
  CellID->1648489289],
-Cell[80153, 2037, 446, 11, 29, "Output",ExpressionUUID->"49ffb29f-cb16-473b-831a-17016fd45619",
+Cell[80258, 2039, 446, 11, 29, "Output",ExpressionUUID->"49ffb29f-cb16-473b-831a-17016fd45619",
  CellID->1472950276]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[80636, 2053, 241, 5, 18, "ExampleDelimiter",ExpressionUUID->"5d74a340-6917-447c-87c5-bf0565f3cb6d",
+Cell[80741, 2055, 241, 5, 18, "ExampleDelimiter",ExpressionUUID->"5d74a340-6917-447c-87c5-bf0565f3cb6d",
  CellID->99302603],
-Cell[80880, 2060, 240, 4, 25, "ExampleText",ExpressionUUID->"3a07e4a7-78c9-4d8c-b8cc-7073838b61bd",
+Cell[80985, 2062, 240, 4, 25, "ExampleText",ExpressionUUID->"3a07e4a7-78c9-4d8c-b8cc-7073838b61bd",
  CellID->9372414],
 Cell[CellGroupData[{
-Cell[81145, 2068, 942, 20, 66, "Input",ExpressionUUID->"b03d019e-4359-4091-b258-ea18cb660537",
+Cell[81250, 2070, 942, 20, 66, "Input",ExpressionUUID->"b03d019e-4359-4091-b258-ea18cb660537",
  CellID->463466769],
-Cell[82090, 2090, 18752, 361, 54, "Output",ExpressionUUID->"41c93f36-298d-49f7-abed-d8cbe4c1bbc1",
+Cell[82195, 2092, 18752, 361, 54, "Output",ExpressionUUID->"41c93f36-298d-49f7-abed-d8cbe4c1bbc1",
  CellID->1877422799]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[100903, 2458, 318, 6, 25, "ExampleSubsection",ExpressionUUID->"2c3516bc-e810-497e-a746-01cd87a15bed",
+Cell[101008, 2460, 318, 6, 25, "ExampleSubsection",ExpressionUUID->"2c3516bc-e810-497e-a746-01cd87a15bed",
  CellID->278998831],
-Cell[101224, 2466, 246, 4, 25, "ExampleText",ExpressionUUID->"a279445f-da19-4b21-9ece-ae57b1aaa295",
+Cell[101329, 2468, 246, 4, 25, "ExampleText",ExpressionUUID->"a279445f-da19-4b21-9ece-ae57b1aaa295",
  CellID->298208290],
 Cell[CellGroupData[{
-Cell[101495, 2474, 692, 16, 46, "Input",ExpressionUUID->"2ad7185a-8710-43ab-8ae0-ca505573c97b",
+Cell[101600, 2476, 692, 16, 46, "Input",ExpressionUUID->"2ad7185a-8710-43ab-8ae0-ca505573c97b",
  CellID->70406071],
-Cell[102190, 2492, 1318, 33, 50, "Output",ExpressionUUID->"85dacf1e-98c6-47b8-891a-ff68170add43",
+Cell[102295, 2494, 1318, 33, 50, "Output",ExpressionUUID->"85dacf1e-98c6-47b8-891a-ff68170add43",
  CellID->2007244601]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[103557, 2531, 316, 6, 25, "ExampleSubsection",ExpressionUUID->"738ff956-e91d-43b0-9e73-fba9256bae54",
+Cell[103662, 2533, 316, 6, 25, "ExampleSubsection",ExpressionUUID->"738ff956-e91d-43b0-9e73-fba9256bae54",
  CellID->251832688],
-Cell[103876, 2539, 591, 12, 43, "ExampleText",ExpressionUUID->"cc0bbb2b-5d55-4bad-97f8-002b8a309462",
+Cell[103981, 2541, 591, 12, 43, "ExampleText",ExpressionUUID->"cc0bbb2b-5d55-4bad-97f8-002b8a309462",
  CellID->270948873],
 Cell[CellGroupData[{
-Cell[104492, 2555, 635, 14, 46, "Input",ExpressionUUID->"e6de82df-bb63-4cb2-880e-d02c5a3d3e5c",
+Cell[104597, 2557, 635, 14, 46, "Input",ExpressionUUID->"e6de82df-bb63-4cb2-880e-d02c5a3d3e5c",
  CellID->676638745],
-Cell[105130, 2571, 255, 6, 26, "Output",ExpressionUUID->"863e7bc8-08f6-4508-8ed7-57b6a1cda360",
+Cell[105235, 2573, 255, 6, 26, "Output",ExpressionUUID->"863e7bc8-08f6-4508-8ed7-57b6a1cda360",
  CellID->993954032]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[105434, 2583, 317, 6, 25, "ExampleSubsection",ExpressionUUID->"2683c412-3ef8-46ce-ae2c-bfe94c1137cb",
+Cell[105539, 2585, 317, 6, 25, "ExampleSubsection",ExpressionUUID->"2683c412-3ef8-46ce-ae2c-bfe94c1137cb",
  CellID->200887691],
-Cell[105754, 2591, 276, 5, 25, "ExampleText",ExpressionUUID->"b8e899f4-7b7e-4eb6-a9c2-bf3e4adac288",
+Cell[105859, 2593, 276, 5, 25, "ExampleText",ExpressionUUID->"b8e899f4-7b7e-4eb6-a9c2-bf3e4adac288",
  CellID->654805157],
 Cell[CellGroupData[{
-Cell[106055, 2600, 1864, 47, 182, "Input",ExpressionUUID->"a616c325-ab33-4119-9ddc-a86d79028566",
+Cell[106160, 2602, 1864, 47, 182, "Input",ExpressionUUID->"a616c325-ab33-4119-9ddc-a86d79028566",
  CellID->1148403],
-Cell[107922, 2649, 3861, 101, 118, "Output",ExpressionUUID->"de9567f6-fe5b-f74f-91ea-38e763a02f28",
+Cell[108027, 2651, 3861, 101, 118, "Output",ExpressionUUID->"de9567f6-fe5b-f74f-91ea-38e763a02f28",
  CellID->374543594]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
-Cell[111822, 2755, 248, 5, 35, "ExampleSection",ExpressionUUID->"5d9c66a9-2524-477e-bda4-777d86e71207",
+Cell[111927, 2757, 248, 5, 35, "ExampleSection",ExpressionUUID->"5d9c66a9-2524-477e-bda4-777d86e71207",
  CellID->317484403],
 Cell[CellGroupData[{
-Cell[112095, 2764, 258, 5, 21, "ExampleSection",ExpressionUUID->"b34fadbf-53bf-4c0f-a2c9-b944d3b156e0",
+Cell[112200, 2766, 258, 5, 21, "ExampleSection",ExpressionUUID->"b34fadbf-53bf-4c0f-a2c9-b944d3b156e0",
  CellID->298852093],
 Cell[CellGroupData[{
-Cell[112378, 2773, 767, 14, 25, "ExampleSubsection",ExpressionUUID->"3390a96f-2b13-6344-bd3a-88875f42664b",
+Cell[112483, 2775, 767, 14, 25, "ExampleSubsection",ExpressionUUID->"3390a96f-2b13-6344-bd3a-88875f42664b",
  CellID->296669070],
-Cell[113148, 2789, 1499, 25, 60, "ExampleText",ExpressionUUID->"fd9c54f6-8d5c-7445-b2b0-bc2558b8ccf2",
+Cell[113253, 2791, 1499, 25, 60, "ExampleText",ExpressionUUID->"fd9c54f6-8d5c-7445-b2b0-bc2558b8ccf2",
  CellID->105689035],
-Cell[114650, 2816, 1656, 27, 43, "ExampleText",ExpressionUUID->"4ab5a89f-9424-804a-bb1e-f3525396ee30",
+Cell[114755, 2818, 1656, 27, 43, "ExampleText",ExpressionUUID->"4ab5a89f-9424-804a-bb1e-f3525396ee30",
  CellID->709734105],
-Cell[116309, 2845, 1444, 28, 78, "ExampleText",ExpressionUUID->"25a88263-624f-9044-b7e9-ffa7d3ad2143",
+Cell[116414, 2847, 1444, 28, 78, "ExampleText",ExpressionUUID->"25a88263-624f-9044-b7e9-ffa7d3ad2143",
  CellID->105347582],
 Cell[CellGroupData[{
-Cell[117778, 2877, 2368, 53, 174, "Input",ExpressionUUID->"b72970c2-2e03-194e-a886-48306db9e1fe",
+Cell[117883, 2879, 2368, 53, 174, "Input",ExpressionUUID->"b72970c2-2e03-194e-a886-48306db9e1fe",
  CellID->448289478],
-Cell[120149, 2932, 2925, 69, 73, "Output",ExpressionUUID->"ee3e6619-0aca-4645-8fcc-15c0257fb24c",
+Cell[120254, 2934, 2925, 69, 73, "Output",ExpressionUUID->"ee3e6619-0aca-4645-8fcc-15c0257fb24c",
  CellID->54729281]
 }, Open  ]],
-Cell[123089, 3004, 1012, 15, 60, "ExampleText",ExpressionUUID->"8426917f-e9a1-9b4a-b254-015f536580c5",
+Cell[123194, 3006, 1012, 15, 60, "ExampleText",ExpressionUUID->"8426917f-e9a1-9b4a-b254-015f536580c5",
  CellID->135010306],
-Cell[124104, 3021, 1301, 20, 60, "ExampleText",ExpressionUUID->"353ad895-6faf-2643-85a6-a8331bb20202",
+Cell[124209, 3023, 1301, 20, 60, "ExampleText",ExpressionUUID->"353ad895-6faf-2643-85a6-a8331bb20202",
  CellID->359104851]
 }, Open  ]]
 }, Open  ]],
-Cell[125432, 3045, 251, 5, 35, "ExampleSection",ExpressionUUID->"6f8a9891-1da3-4c2a-8d54-2a23b4e48ef2",
+Cell[125537, 3047, 251, 5, 35, "ExampleSection",ExpressionUUID->"6f8a9891-1da3-4c2a-8d54-2a23b4e48ef2",
  CellID->221762665],
-Cell[125686, 3052, 256, 5, 21, "ExampleSection",ExpressionUUID->"0ae43145-54ab-47b0-853b-c06f35087266",
+Cell[125791, 3054, 256, 5, 21, "ExampleSection",ExpressionUUID->"0ae43145-54ab-47b0-853b-c06f35087266",
  CellID->194169788],
-Cell[125945, 3059, 249, 5, 21, "ExampleSection",ExpressionUUID->"df11dd4a-6677-4027-850d-81be8390d86e",
+Cell[126050, 3061, 249, 5, 21, "ExampleSection",ExpressionUUID->"df11dd4a-6677-4027-850d-81be8390d86e",
  CellID->205778757]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[126231, 3069, 110, 1, 78, "MetadataSection",ExpressionUUID->"f42a207b-c1a5-4b72-bffd-171b7c78e43a",
+Cell[126336, 3071, 110, 1, 78, "MetadataSection",ExpressionUUID->"f42a207b-c1a5-4b72-bffd-171b7c78e43a",
  CellID->892947207],
-Cell[126344, 3072, 474, 12, 28, "History",ExpressionUUID->"043659d4-bd7a-41e3-8d6d-5096845cfc0e",
+Cell[126449, 3074, 474, 12, 28, "History",ExpressionUUID->"043659d4-bd7a-41e3-8d6d-5096845cfc0e",
  CellID->5319953],
 Cell[CellGroupData[{
-Cell[126843, 3088, 483, 13, 22, "CategorizationSection",ExpressionUUID->"f42be207-fac4-45ff-9b65-f94b8dd6fd9f",
+Cell[126948, 3090, 483, 13, 22, "CategorizationSection",ExpressionUUID->"f42be207-fac4-45ff-9b65-f94b8dd6fd9f",
  CellID->99447318],
-Cell[127329, 3103, 134, 2, 37, "Categorization",ExpressionUUID->"c778a203-35fe-4567-93f1-8c6b1bcd183f",
+Cell[127434, 3105, 134, 2, 37, "Categorization",ExpressionUUID->"c778a203-35fe-4567-93f1-8c6b1bcd183f",
  CellID->280483579],
-Cell[127466, 3107, 159, 2, 37, "Categorization",ExpressionUUID->"2a039ea4-f2c3-46b2-9d95-f31ba7977b39",
+Cell[127571, 3109, 159, 2, 37, "Categorization",ExpressionUUID->"2a039ea4-f2c3-46b2-9d95-f31ba7977b39",
  CellID->513088406],
-Cell[127628, 3111, 156, 2, 37, "Categorization",ExpressionUUID->"1a707789-5b23-4dca-b002-5ed992e7c839",
+Cell[127733, 3113, 156, 2, 37, "Categorization",ExpressionUUID->"1a707789-5b23-4dca-b002-5ed992e7c839",
  CellID->424615657],
-Cell[127787, 3115, 268, 5, 37, "Categorization",ExpressionUUID->"a1b1c2fc-53fa-431d-a0fe-f18cd23daaba",
+Cell[127892, 3117, 268, 5, 37, "Categorization",ExpressionUUID->"a1b1c2fc-53fa-431d-a0fe-f18cd23daaba",
  CellID->324277285]
 }, Closed]],
 Cell[CellGroupData[{
-Cell[128092, 3125, 110, 1, 23, "KeywordsSection",ExpressionUUID->"37f42972-c976-465c-86ba-9ab841d611b5",
+Cell[128197, 3127, 110, 1, 23, "KeywordsSection",ExpressionUUID->"37f42972-c976-465c-86ba-9ab841d611b5",
  CellID->157024413],
-Cell[128205, 3128, 99, 1, 21, "Keywords",ExpressionUUID->"b50ec6a9-d57d-4e72-b445-88cf73b961f7",
+Cell[128310, 3130, 99, 1, 21, "Keywords",ExpressionUUID->"b50ec6a9-d57d-4e72-b445-88cf73b961f7",
  CellID->369608981]
 }, Closed]],
 Cell[CellGroupData[{
-Cell[128341, 3134, 118, 1, 23, "TemplatesSection",ExpressionUUID->"7ad12944-0259-4015-87e6-e35907a9425a",
+Cell[128446, 3136, 118, 1, 23, "TemplatesSection",ExpressionUUID->"7ad12944-0259-4015-87e6-e35907a9425a",
  CellID->30111239],
-Cell[128462, 3137, 148, 2, 29, "Template",ExpressionUUID->"73cd4a0a-b323-440e-aafa-198f5e56a0cd",
+Cell[128567, 3139, 148, 2, 29, "Template",ExpressionUUID->"73cd4a0a-b323-440e-aafa-198f5e56a0cd",
  CellID->212216560],
-Cell[128613, 3141, 137, 2, 29, "Template",ExpressionUUID->"954f59e2-12e7-4b48-89ad-b7e99ee0344d",
+Cell[128718, 3143, 137, 2, 29, "Template",ExpressionUUID->"954f59e2-12e7-4b48-89ad-b7e99ee0344d",
  CellID->393173875],
-Cell[128753, 3145, 135, 2, 29, "Template",ExpressionUUID->"5a4f48b7-d6e5-4ac6-a99d-27c2b08ba3a6",
+Cell[128858, 3147, 135, 2, 29, "Template",ExpressionUUID->"5a4f48b7-d6e5-4ac6-a99d-27c2b08ba3a6",
  CellID->140031180],
-Cell[128891, 3149, 136, 2, 29, "Template",ExpressionUUID->"ea191618-1ca8-4fd2-b80f-eeec0e7640b0",
+Cell[128996, 3151, 136, 2, 29, "Template",ExpressionUUID->"ea191618-1ca8-4fd2-b80f-eeec0e7640b0",
  CellID->94782372]
 }, Closed]]
 }, Open  ]]

--- a/Paclet/Documentation/English/ReferencePages/Symbols/NonReciprocalAbelianBlochHamiltonian.nb
+++ b/Paclet/Documentation/English/ReferencePages/Symbols/NonReciprocalAbelianBlochHamiltonian.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[    125486,       3068]
-NotebookOptionsPosition[    111822,       2774]
-NotebookOutlinePosition[    112628,       2800]
-CellTagsIndexPosition[    112547,       2795]
+NotebookDataLength[    139628,       3365]
+NotebookOptionsPosition[    124878,       3049]
+NotebookOutlinePosition[    125684,       3075]
+CellTagsIndexPosition[    125603,       3070]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -453,10 +453,10 @@ AbelianBlochHamiltonianExpression"]], "InlineSeeAlsoFunction",
     "40a5967c-b2d7-4ad4-bb67-87cb6c247423"], 
    DynamicModuleBox[{$CellContext`nbobj$$ = NotebookObject[
     "ca524783-33ba-4436-a7c7-e9b68abdb844", 
-     "1d6237b8-b6b5-aa41-9799-963dcbf87367"], $CellContext`cellobj$$ = 
+     "7c289219-9f2e-6046-ab73-6e12af829af9"], $CellContext`cellobj$$ = 
     CellObject[
     "f192ff71-19a1-4a57-b3cc-520a4f08fea8", 
-     "2a83925f-ce99-6648-adfa-5266ca5294db"]}, 
+     "37d6b5d7-23f1-b44f-9000-fdd70011d409"]}, 
     TemplateBox[{
       GraphicsBox[{{
          Thickness[0.06], 
@@ -484,8 +484,8 @@ AbelianBlochHamiltonianExpression"]], "InlineSeeAlsoFunction",
  CellChangeTimes->{{3.906081385224657*^9, 3.906081393032315*^9}, {
   3.906081431010906*^9, 3.906081446001929*^9}, {3.93450616595286*^9, 
   3.93450624807312*^9}, {3.9345063104834785`*^9, 3.934506330963293*^9}, {
-  3.9374049102532196`*^9, 3.937404915982052*^9}, {3.9400952283675175`*^9, 
-  3.9400952383173943`*^9}, {3.940095303675123*^9, 3.940095309225073*^9}},
+  3.937404910253219*^9, 3.937404915982052*^9}, {3.940095228367518*^9, 
+  3.940095238317395*^9}, {3.940095303675123*^9, 3.940095309225073*^9}},
  CellID->381155944,ExpressionUUID->"dbc05f00-cfba-473e-bc6d-ca3adf85f088"]
 }, Open  ]],
 
@@ -547,8 +547,8 @@ Cell[BoxData[
  CellID->287190428,ExpressionUUID->"d2f8cf66-026c-48d5-a784-375f28f06a2d"],
 
 Cell[TextData[{
- "Construct the Abelian Bloch Hamiltonian of an elementary nearest-neighbor \
-hopping model defined on an ",
+ "Construct the non-reciprocal Abelian Bloch Hamiltonian of an elementary \
+nearest-neighbor hopping model defined on an ",
  Cell[BoxData[
   ButtonBox["HCModelGraph",
    BaseStyle->"Link",
@@ -562,7 +562,7 @@ in canonical and opposite to the canonical direction, respectively:"
   3.9060287922921596`*^9, 3.906028807134487*^9}, {3.9345071774232864`*^9, 
   3.9345071795629616`*^9}, {3.934507342442824*^9, 3.93450742533321*^9}, {
   3.934507810362931*^9, 3.934507819672989*^9}, {3.9345080614427013`*^9, 
-  3.934508103447901*^9}},
+  3.934508103447901*^9}, {3.955167704822487*^9, 3.955167708322012*^9}},
  CellID->82755364,ExpressionUUID->"ebb1feb3-0056-4f70-a821-cb75db877955"],
 
 Cell[CellGroupData[{
@@ -2655,12 +2655,287 @@ Cell[BoxData[
   $Line = 0; Null]], "ExampleSection",
  CellID->317484403,ExpressionUUID->"5d9c66a9-2524-477e-bda4-777d86e71207"],
 
+Cell[CellGroupData[{
+
 Cell[BoxData[
  InterpretationBox[Cell[
   "Properties & Relations", "ExampleSection",ExpressionUUID->
    "cd891dd0-09b7-44b4-bae0-425b36ffc5e4"],
   $Line = 0; Null]], "ExampleSection",
  CellID->298852093,ExpressionUUID->"b34fadbf-53bf-4c0f-a2c9-b944d3b156e0"],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ InterpretationBox[Cell[TextData[Cell[BoxData[
+   InterpretationBox[Cell[
+    "Multiple orbitals", "ExampleSubsection",ExpressionUUID->
+     "cba59b7a-5e0e-cf44-b6db-ac80d486eccb"],
+    $Line = 0; Null]],
+   CellChangeTimes->{{3.9060313294514136`*^9, 3.906031330419829*^9}, {
+    3.9374005375764217`*^9, 3.937400540021569*^9}},ExpressionUUID->
+   "4f180156-c70d-1940-870b-45d9ee9bddc5"]], "ExampleSubsection",
+   ExpressionUUID->"1231e9d3-b771-724d-99f0-0109afa16c72"],
+  $Line = 0; Null]], "ExampleSubsection",
+ CellChangeTimes->{{3.9060313294514136`*^9, 3.906031330419829*^9}, {
+  3.937405053908352*^9, 3.937405065322071*^9}, {3.9551680429373455`*^9, 
+  3.95516805009239*^9}},
+ CellID->296669070,ExpressionUUID->"3390a96f-2b13-6344-bd3a-88875f42664b"],
+
+Cell[TextData[{
+ "Non-reciprocal Abelian Bloch Hamiltonians are constructed through a \
+generalization of the function  ",
+ Cell[BoxData[
+  ButtonBox["AbelianBlochHamiltonian",
+   BaseStyle->"Link",
+   ButtonData->
+    "paclet:PatrickMLenggenhager/HyperBloch/ref/AbelianBlochHamiltonian"]], 
+  "InlineFormula",ExpressionUUID->"2bb6ddac-3982-b04e-9f5e-0c72bceb16db"],
+ ". As such, the onsite potential and the hopping amplitudes are specified \
+analogously. Crucially, the following convention is imposed:"
+}], "ExampleText",
+ CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
+   3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
+   3.906028831115154*^9}, {3.906028997135098*^9, 3.906029000923377*^9}, 
+   3.9345103390559063`*^9, {3.937421005016327*^9, 3.9374210159177094`*^9}, {
+   3.9551673567773075`*^9, 3.955167361081892*^9}, {3.955168934862646*^9, 
+   3.9551689986790257`*^9}, {3.9551691386825943`*^9, 
+   3.9551691946723156`*^9}, {3.955169256152302*^9, 3.9551694931826744`*^9}, {
+   3.955169586572748*^9, 3.9551697126776447`*^9}, {3.955169791552847*^9, 
+   3.9551697986726894`*^9}, {3.955169850973112*^9, 3.9551698519929733`*^9}, {
+   3.9551699271128254`*^9, 3.955170211827799*^9}, {3.955170242038122*^9, 
+   3.955170255833084*^9}, {3.955170301413376*^9, 3.9551703913169937`*^9}, {
+   3.955170445563442*^9, 3.9551705987731857`*^9}, {3.95517525090296*^9, 
+   3.955175264852995*^9}},
+ CellID->105689035,ExpressionUUID->"fd9c54f6-8d5c-7445-b2b0-bc2558b8ccf2"],
+
+Cell[TextData[{
+ "To specify the hopping matrix for the hopping amplitudes  ",
+ Cell[BoxData[
+  StyleBox["hoppingsOpposite", "TI"]], "InlineFormula",ExpressionUUID->
+  "83bd0532-97da-f248-8b17-51a00579e4fb"],
+ " appropriately, the positions of the matrix entries for each pair of \
+orbitals is inherited from the hopping matrix ",
+ Cell[BoxData[
+  StyleBox["hoppingsCanonical", "TI"]], "InlineFormula",ExpressionUUID->
+  "9966380f-fb2b-ba4d-9f24-ab65e5d9d312"],
+ ". "
+}], "ExampleText",
+ CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
+   3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
+   3.906028831115154*^9}, {3.906028997135098*^9, 3.906029000923377*^9}, 
+   3.9345103390559063`*^9, {3.937421005016327*^9, 3.9374210159177094`*^9}, {
+   3.9551673567773075`*^9, 3.955167361081892*^9}, {3.955168934862646*^9, 
+   3.9551689986790257`*^9}, {3.9551691386825943`*^9, 
+   3.9551691946723156`*^9}, {3.955169256152302*^9, 3.9551694931826744`*^9}, {
+   3.955169586572748*^9, 3.9551697126776447`*^9}, {3.955169791552847*^9, 
+   3.9551697986726894`*^9}, {3.955169850973112*^9, 3.9551698519929733`*^9}, {
+   3.9551699271128254`*^9, 3.955170211827799*^9}, {3.955170242038122*^9, 
+   3.955170255833084*^9}, {3.955170301413376*^9, 3.9551703913169937`*^9}, {
+   3.955170445563442*^9, 3.955170745103998*^9}, {3.95517080197999*^9, 
+   3.955170813024542*^9}, {3.955171255916292*^9, 3.9551712615131607`*^9}, {
+   3.955172093403908*^9, 3.9551720938842525`*^9}},
+ CellID->709734105,ExpressionUUID->"4ab5a89f-9424-804a-bb1e-f3525396ee30"],
+
+Cell[TextData[{
+ "For example, the non-reciprocal Abelian Bloch Hamiltonian of a hopping \
+model defined on an ",
+ Cell[BoxData[
+  ButtonBox["HCModelGraph",
+   BaseStyle->"Link",
+   ButtonData->"paclet:PatrickMLenggenhager/HyperBloch/ref/HCModelGraph"]], 
+  "InlineFormula",ExpressionUUID->"361722a6-dd87-4748-8c88-857e4076a61b"],
+ " (here the primitive cell of the {8,8} tessellation) with hopping \
+amplitudes ",
+ Cell[BoxData[
+  StyleBox["hoppingsCanonical", "TI"]], "InlineFormula",ExpressionUUID->
+  "1fd362b5-2099-ba44-9f85-921d8f48ee24"],
+ " in the canonical directions and ",
+ Cell[BoxData[
+  StyleBox["hoppingsOpposite", "TI"]], "InlineFormula",ExpressionUUID->
+  "cbe8e33b-43dd-084e-be6e-5f718ea4a643"],
+ " in the opposite directions and two orbitals per site, using symbolic \
+arguments, is:"
+}], "ExampleText",
+ CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
+   3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
+   3.906028831115154*^9}, {3.906028997135098*^9, 3.906029000923377*^9}, 
+   3.9345103390559063`*^9, {3.937421005016327*^9, 3.9374210159177094`*^9}, {
+   3.9551673567773075`*^9, 3.955167361081892*^9}, {3.955169884838175*^9, 
+   3.955169900892893*^9}, {3.9551712636836224`*^9, 3.9551712747634583`*^9}, {
+   3.9551714818336887`*^9, 3.9551715032236137`*^9}, {3.955172112773716*^9, 
+   3.955172113753664*^9}},
+ CellID->105347582,ExpressionUUID->"25a88263-624f-9044-b7e9-ffa7d3ad2143"],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[{
+ RowBox[{
+  RowBox[{"modelgraph", "=", 
+   RowBox[{"HCExampleData", "[", "\"\<{8,8}-tess_T2.6_3.hcm\>\"", "]"}]}], 
+  ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"onsite", "=", 
+   RowBox[{
+    RowBox[{"(", GridBox[{
+       {"0", 
+        RowBox[{"-", "t1"}]},
+       {"t1", "0"}
+      }], ")"}], "&"}]}], ";"}], "\n", 
+ RowBox[{
+  RowBox[{"hoppingsCanonical", "=", 
+   RowBox[{
+    RowBox[{
+     RowBox[{"-", "t2"}], 
+     RowBox[{"(", GridBox[{
+        {"0", "1"},
+        {"1", "0"}
+       }], ")"}]}], "&"}]}], ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"hoppingsOpposite", " ", "=", 
+   RowBox[{
+    RowBox[{"t2", 
+     RowBox[{"(", GridBox[{
+        {"0", "1"},
+        {"1", "0"}
+       }], ")"}]}], "&"}]}], ";"}], "\[IndentingNewLine]", 
+ RowBox[{"NonReciprocalAbelianBlochHamiltonian", "[", 
+  RowBox[{"modelgraph", ",", 
+   RowBox[{"2", "&"}], ",", "onsite", ",", "hoppingsCanonical", ",", 
+   "hoppingsOpposite"}], "]"}]}], "Input",
+ CellChangeTimes->{{3.906027063408805*^9, 3.906027088319622*^9}, {
+   3.9060271833899145`*^9, 3.906027223799124*^9}, 3.906028315145218*^9, {
+   3.906028607996865*^9, 3.906028613837571*^9}, {3.9060286781196327`*^9, 
+   3.906028694807095*^9}, {3.906028732857873*^9, 3.906028753463425*^9}, {
+   3.906028853588249*^9, 3.906028970614804*^9}, {3.906029009568014*^9, 
+   3.9060291359216547`*^9}, 3.906435166479804*^9, 3.918641100224955*^9, 
+   3.918641526860538*^9, {3.934510346885731*^9, 3.934510363362161*^9}, {
+   3.934512248861981*^9, 3.934512249102097*^9}, {3.937421018680098*^9, 
+   3.937421039864488*^9}, 3.9551685771625175`*^9, {3.9551686636921463`*^9, 
+   3.9551686812375736`*^9}, {3.9551688907523804`*^9, 3.955168898442978*^9}, {
+   3.9551715089333115`*^9, 3.9551715174531784`*^9}, {3.9551722334739017`*^9, 
+   3.9551722813437862`*^9}, {3.9551731788246975`*^9, 
+   3.9551732107602386`*^9}, {3.955173241444565*^9, 3.9551732573395042`*^9}, {
+   3.9551736999744873`*^9, 3.955173717554676*^9}, {3.955173754074892*^9, 
+   3.9551737789347763`*^9}, {3.9551738764048176`*^9, 3.955173881875292*^9}, {
+   3.955173958940502*^9, 3.955173964274702*^9}, {3.955174224704588*^9, 
+   3.9551742286749134`*^9}, {3.955174273904991*^9, 3.9551742763650055`*^9}, {
+   3.955175230012764*^9, 3.9551752385026073`*^9}},
+ CellLabel->"In[1]:=",
+ CellID->448289478,ExpressionUUID->"b72970c2-2e03-194e-a886-48306db9e1fe"],
+
+Cell[BoxData[
+ RowBox[{"Function", "[", 
+  RowBox[{
+   RowBox[{"{", 
+    RowBox[{"k1", ",", "k2", ",", "k3", ",", "k4"}], "}"}], ",", 
+   RowBox[{"{", 
+    RowBox[{
+     RowBox[{"{", 
+      RowBox[{"0", ",", 
+       RowBox[{
+        RowBox[{"-", "t1"}], "+", 
+        RowBox[{
+         RowBox[{"(", 
+          RowBox[{
+           SuperscriptBox["\[ExponentialE]", 
+            RowBox[{
+             RowBox[{"-", "\[ImaginaryI]"}], " ", "k1"}]], "-", 
+           SuperscriptBox["\[ExponentialE]", 
+            RowBox[{"\[ImaginaryI]", " ", "k1"}]], "+", 
+           SuperscriptBox["\[ExponentialE]", 
+            RowBox[{
+             RowBox[{"-", "\[ImaginaryI]"}], " ", "k2"}]], "-", 
+           SuperscriptBox["\[ExponentialE]", 
+            RowBox[{"\[ImaginaryI]", " ", "k2"}]], "+", 
+           SuperscriptBox["\[ExponentialE]", 
+            RowBox[{
+             RowBox[{"-", "\[ImaginaryI]"}], " ", "k3"}]], "-", 
+           SuperscriptBox["\[ExponentialE]", 
+            RowBox[{"\[ImaginaryI]", " ", "k3"}]], "+", 
+           SuperscriptBox["\[ExponentialE]", 
+            RowBox[{
+             RowBox[{"-", "\[ImaginaryI]"}], " ", "k4"}]], "-", 
+           SuperscriptBox["\[ExponentialE]", 
+            RowBox[{"\[ImaginaryI]", " ", "k4"}]]}], ")"}], " ", "t2"}]}]}], 
+      "}"}], ",", 
+     RowBox[{"{", 
+      RowBox[{
+       RowBox[{"t1", "+", 
+        RowBox[{
+         RowBox[{"(", 
+          RowBox[{
+           SuperscriptBox["\[ExponentialE]", 
+            RowBox[{
+             RowBox[{"-", "\[ImaginaryI]"}], " ", "k1"}]], "-", 
+           SuperscriptBox["\[ExponentialE]", 
+            RowBox[{"\[ImaginaryI]", " ", "k1"}]], "+", 
+           SuperscriptBox["\[ExponentialE]", 
+            RowBox[{
+             RowBox[{"-", "\[ImaginaryI]"}], " ", "k2"}]], "-", 
+           SuperscriptBox["\[ExponentialE]", 
+            RowBox[{"\[ImaginaryI]", " ", "k2"}]], "+", 
+           SuperscriptBox["\[ExponentialE]", 
+            RowBox[{
+             RowBox[{"-", "\[ImaginaryI]"}], " ", "k3"}]], "-", 
+           SuperscriptBox["\[ExponentialE]", 
+            RowBox[{"\[ImaginaryI]", " ", "k3"}]], "+", 
+           SuperscriptBox["\[ExponentialE]", 
+            RowBox[{
+             RowBox[{"-", "\[ImaginaryI]"}], " ", "k4"}]], "-", 
+           SuperscriptBox["\[ExponentialE]", 
+            RowBox[{"\[ImaginaryI]", " ", "k4"}]]}], ")"}], " ", "t2"}]}], 
+       ",", "0"}], "}"}]}], "}"}]}], "]"}]], "Output",
+ CellChangeTimes->{{3.9345122365517464`*^9, 3.9345122365718365`*^9}, 
+   3.9551686897425213`*^9, 3.955168894992527*^9, 3.9551715580633907`*^9, 
+   3.9551731943463783`*^9, 3.9551732584047394`*^9, 3.9551737220747166`*^9, 
+   3.9551738227094727`*^9, 3.9551738833143463`*^9, 3.9551742297750053`*^9, 
+   3.9551742771349545`*^9, {3.955175233942772*^9, 3.955175240372587*^9}, 
+   3.955175340412508*^9},
+ CellLabel->"Out[5]=",
+ CellID->54729281,ExpressionUUID->"ee3e6619-0aca-4645-8fcc-15c0257fb24c"]
+}, Open  ]],
+
+Cell["\<\
+Specifically, we have set the mass terms of the orbitals to zero, the \
+intra-cell coupling to -t1 in the canonical direction and t1 in the opposite \
+direction and the inter-cell coupling to -t2  in the canonical direction and \
+t2 in the opposite direction.\
+\>", "ExampleText",
+ CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
+   3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
+   3.906028831115154*^9}, {3.906028997135098*^9, 3.906029000923377*^9}, 
+   3.9345103390559063`*^9, {3.937421005016327*^9, 3.9374210159177094`*^9}, {
+   3.9551673567773075`*^9, 3.955167361081892*^9}, {3.955169884838175*^9, 
+   3.955169900892893*^9}, {3.9551712636836224`*^9, 3.9551712747634583`*^9}, {
+   3.9551714818336887`*^9, 3.9551715032236137`*^9}, {3.955172112773716*^9, 
+   3.955172113753664*^9}, {3.955172958744713*^9, 3.9551729998145275`*^9}, {
+   3.9551738888346024`*^9, 3.955174072975092*^9}},
+ CellID->135010306,ExpressionUUID->"8426917f-e9a1-9b4a-b254-015f536580c5"],
+
+Cell[TextData[{
+ "Note, for the specification of the hopping matrix ",
+ Cell[BoxData[
+  StyleBox["hoppingsOpposite", "TI"]], "InlineFormula",ExpressionUUID->
+  "7e156c0c-aa14-144e-80b9-0e46027671bf"],
+ " it is instructive to think of constructing an Abelian Bloch Hamiltonian \
+with adjusted hopping amplitudes. The location of the matrix entries, \
+signifying which orbitals are couped, are not to be adjusted."
+}], "ExampleText",
+ CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
+   3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
+   3.906028831115154*^9}, {3.906028997135098*^9, 3.906029000923377*^9}, 
+   3.9345103390559063`*^9, {3.937421005016327*^9, 3.9374210159177094`*^9}, {
+   3.9551673567773075`*^9, 3.955167361081892*^9}, {3.955169884838175*^9, 
+   3.955169900892893*^9}, {3.9551712636836224`*^9, 3.9551712747634583`*^9}, {
+   3.9551714818336887`*^9, 3.9551715032236137`*^9}, {3.9551715785834274`*^9, 
+   3.955171787968336*^9}, {3.9551718215979214`*^9, 3.955171921880068*^9}, {
+   3.955171980553753*^9, 3.95517204996364*^9}, {3.9551721380934505`*^9, 
+   3.955172210473549*^9}, {3.955172312600815*^9, 3.95517231343186*^9}, {
+   3.955172798924677*^9, 3.9551728555947685`*^9}},
+ CellID->359104851,ExpressionUUID->"353ad895-6faf-2643-85a6-a8331bb20202"]
+}, Open  ]]
+}, Open  ]],
 
 Cell[BoxData[
  InterpretationBox[Cell[
@@ -2787,14 +3062,14 @@ ExpressionUUID->"ca524783-33ba-4436-a7c7-e9b68abdb844"
 (*CellTagsOutline
 CellTagsIndex->{
  "ExtendedExamples"->{
-  Cell[40482, 1080, 485, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"67ec221c-caf6-4173-ad73-9d17ddeabdd0",
+  Cell[40537, 1080, 485, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"67ec221c-caf6-4173-ad73-9d17ddeabdd0",
    CellTags->"ExtendedExamples",
    CellID->9214842]}
  }
 *)
 (*CellTagsIndex
 CellTagsIndex->{
- {"ExtendedExamples", 112354, 2788}
+ {"ExtendedExamples", 125410, 3063}
  }
 *)
 (*NotebookFileOutline
@@ -2836,237 +3111,259 @@ Cell[13560, 360, 103, 1, 19, "RelatedLinks",ExpressionUUID->"79cdcc1a-2b16-4dc9-
 Cell[CellGroupData[{
 Cell[13700, 366, 458, 13, 39, "SeeAlsoSection",ExpressionUUID->"050b63cf-bf1c-4662-94e7-626aec5d6b33",
  CellID->223461721],
-Cell[14161, 381, 4485, 107, 62, "SeeAlso",ExpressionUUID->"dbc05f00-cfba-473e-bc6d-ca3adf85f088",
+Cell[14161, 381, 4479, 107, 62, "SeeAlso",ExpressionUUID->"dbc05f00-cfba-473e-bc6d-ca3adf85f088",
  CellID->381155944]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[18683, 493, 182, 2, 39, "MoreAboutSection",ExpressionUUID->"628c56fb-2a64-454a-afda-0c72e8b98f07",
+Cell[18677, 493, 182, 2, 39, "MoreAboutSection",ExpressionUUID->"628c56fb-2a64-454a-afda-0c72e8b98f07",
  CellID->31221473],
-Cell[18868, 497, 281, 6, 19, "MoreAbout",ExpressionUUID->"f716947c-4c12-47a4-9cff-f2a24ce82555",
+Cell[18862, 497, 281, 6, 19, "MoreAbout",ExpressionUUID->"f716947c-4c12-47a4-9cff-f2a24ce82555",
  CellID->542581366]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[19186, 508, 530, 14, 69, "ExamplesInitializationSection",ExpressionUUID->"d27dce01-6ac7-4a45-a9d6-0701f911e181",
+Cell[19180, 508, 530, 14, 69, "ExamplesInitializationSection",ExpressionUUID->"d27dce01-6ac7-4a45-a9d6-0701f911e181",
  CellID->428868112],
-Cell[19719, 524, 306, 5, 45, "ExampleInitialization",ExpressionUUID->"b9b2fab4-94b0-40ca-9b3a-2f0308baac5d",
+Cell[19713, 524, 306, 5, 45, "ExampleInitialization",ExpressionUUID->"b9b2fab4-94b0-40ca-9b3a-2f0308baac5d",
  CellID->127019986]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[20062, 534, 442, 12, 71, "PrimaryExamplesSection",ExpressionUUID->"d2f8cf66-026c-48d5-a784-375f28f06a2d",
+Cell[20056, 534, 442, 12, 71, "PrimaryExamplesSection",ExpressionUUID->"d2f8cf66-026c-48d5-a784-375f28f06a2d",
  CellID->287190428],
-Cell[20507, 548, 972, 17, 77, "ExampleText",ExpressionUUID->"ebb1feb3-0056-4f70-a821-cb75db877955",
+Cell[20501, 548, 1033, 17, 77, "ExampleText",ExpressionUUID->"ebb1feb3-0056-4f70-a821-cb75db877955",
  CellID->82755364],
 Cell[CellGroupData[{
-Cell[21504, 569, 879, 17, 43, "Input",ExpressionUUID->"1801ac2d-56d7-4398-bb12-0df44e788296",
+Cell[21559, 569, 879, 17, 43, "Input",ExpressionUUID->"1801ac2d-56d7-4398-bb12-0df44e788296",
  CellID->2282893],
-Cell[22386, 588, 1250, 32, 28, "Output",ExpressionUUID->"d85b87b9-5ea5-e142-aa96-c5defb7f74a6",
+Cell[22441, 588, 1250, 32, 28, "Output",ExpressionUUID->"d85b87b9-5ea5-e142-aa96-c5defb7f74a6",
  CellID->358951349]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[23673, 625, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"922de4a1-c33d-4c53-8420-c637e7f021b3",
+Cell[23728, 625, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"922de4a1-c33d-4c53-8420-c637e7f021b3",
  CellID->359821871],
-Cell[23918, 632, 286, 4, 24, "ExampleText",ExpressionUUID->"d5d6071a-bed5-46eb-8714-d433cf53be67",
+Cell[23973, 632, 286, 4, 24, "ExampleText",ExpressionUUID->"d5d6071a-bed5-46eb-8714-d433cf53be67",
  CellID->36408547],
 Cell[CellGroupData[{
-Cell[24229, 640, 877, 18, 43, "Input",ExpressionUUID->"3866cf54-8397-470a-83a7-afd78dfcc355",
+Cell[24284, 640, 877, 18, 43, "Input",ExpressionUUID->"3866cf54-8397-470a-83a7-afd78dfcc355",
  CellID->633400500],
-Cell[25109, 660, 1518, 41, 47, "Output",ExpressionUUID->"200b00c8-9201-854c-8f51-7bbc82880d34",
+Cell[25164, 660, 1518, 41, 47, "Output",ExpressionUUID->"200b00c8-9201-854c-8f51-7bbc82880d34",
  CellID->597007231]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[26676, 707, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"91af1e5a-0ac3-4065-ada3-09c2fcae8951",
+Cell[26731, 707, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"91af1e5a-0ac3-4065-ada3-09c2fcae8951",
  CellID->677196106],
-Cell[26921, 714, 1465, 30, 79, "ExampleText",ExpressionUUID->"ec5d7117-2c96-4cd7-8c70-8feb237d9c1a",
+Cell[26976, 714, 1465, 30, 79, "ExampleText",ExpressionUUID->"ec5d7117-2c96-4cd7-8c70-8feb237d9c1a",
  CellID->680708440],
 Cell[CellGroupData[{
-Cell[28411, 748, 5169, 145, 310, "Input",ExpressionUUID->"85e83bbc-1b5b-4ac6-911c-21ee445d4a06",
+Cell[28466, 748, 5169, 145, 310, "Input",ExpressionUUID->"85e83bbc-1b5b-4ac6-911c-21ee445d4a06",
  CellID->262417576],
-Cell[33583, 895, 1425, 38, 46, "Output",ExpressionUUID->"b1c315d3-d6ca-9e46-a19e-45e561f5a488",
+Cell[33638, 895, 1425, 38, 47, "Output",ExpressionUUID->"b1c315d3-d6ca-9e46-a19e-45e561f5a488",
  CellID->238453336]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[35057, 939, 242, 5, 18, "ExampleDelimiter",ExpressionUUID->"91af2a9a-8d2e-4cc0-9108-b1a6077fc751",
+Cell[35112, 939, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"91af2a9a-8d2e-4cc0-9108-b1a6077fc751",
  CellID->228953716],
-Cell[35302, 946, 1231, 24, 58, "ExampleText",ExpressionUUID->"fcdd41cc-dab8-4085-956b-4fbaead769ff",
+Cell[35357, 946, 1231, 24, 60, "ExampleText",ExpressionUUID->"fcdd41cc-dab8-4085-956b-4fbaead769ff",
  CellID->16699796],
 Cell[CellGroupData[{
-Cell[36558, 974, 1576, 40, 159, "Input",ExpressionUUID->"4f1af21c-17c3-43e9-bcd5-c3315c7f5030",
+Cell[36613, 974, 1576, 40, 159, "Input",ExpressionUUID->"4f1af21c-17c3-43e9-bcd5-c3315c7f5030",
  CellID->78835713],
-Cell[38137, 1016, 2284, 57, 48, "Output",ExpressionUUID->"a350b281-9026-a242-a927-5a1487fff681",
+Cell[38192, 1016, 2284, 57, 67, "Output",ExpressionUUID->"a350b281-9026-a242-a927-5a1487fff681",
  CellID->316316822]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[40482, 1080, 485, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"67ec221c-caf6-4173-ad73-9d17ddeabdd0",
+Cell[40537, 1080, 485, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"67ec221c-caf6-4173-ad73-9d17ddeabdd0",
  CellTags->"ExtendedExamples",
  CellID->9214842],
 Cell[CellGroupData[{
-Cell[40992, 1097, 241, 5, 35, "ExampleSection",ExpressionUUID->"7926246e-3782-40ac-be88-4537478d26ce",
+Cell[41047, 1097, 241, 5, 35, "ExampleSection",ExpressionUUID->"7926246e-3782-40ac-be88-4537478d26ce",
  CellID->403151183],
 Cell[CellGroupData[{
-Cell[41258, 1106, 182, 2, 23, "ExampleSubsection",ExpressionUUID->"95a98044-a233-4544-9891-89bb53f5a862",
+Cell[41313, 1106, 182, 2, 24, "ExampleSubsection",ExpressionUUID->"95a98044-a233-4544-9891-89bb53f5a862",
  CellID->198501545],
-Cell[41443, 1110, 327, 6, 40, "ExampleText",ExpressionUUID->"57b954c0-b7e2-4f82-aadb-289efe4b7cba",
+Cell[41498, 1110, 327, 6, 41, "ExampleText",ExpressionUUID->"57b954c0-b7e2-4f82-aadb-289efe4b7cba",
  CellID->293180495],
-Cell[41773, 1118, 578, 14, 43, "Input",ExpressionUUID->"89618398-f380-475c-b7e4-e054099d4d43",
+Cell[41828, 1118, 578, 14, 43, "Input",ExpressionUUID->"89618398-f380-475c-b7e4-e054099d4d43",
  CellID->407621152],
 Cell[CellGroupData[{
-Cell[42376, 1136, 454, 10, 25, "Input",ExpressionUUID->"6caac9fb-623b-44e4-a9f7-b8e4a66a4a73",
+Cell[42431, 1136, 454, 10, 25, "Input",ExpressionUUID->"6caac9fb-623b-44e4-a9f7-b8e4a66a4a73",
  CellID->244028921],
-Cell[42833, 1148, 474, 10, 23, "Output",ExpressionUUID->"1eaf42c8-938e-6640-8167-cfe868768b18",
+Cell[42888, 1148, 474, 10, 24, "Output",ExpressionUUID->"1eaf42c8-938e-6640-8167-cfe868768b18",
  CellID->389831821]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[43344, 1163, 636, 14, 43, "Input",ExpressionUUID->"7868a0e3-097b-4ce5-9a31-85049d14dd19",
+Cell[43399, 1163, 636, 14, 43, "Input",ExpressionUUID->"7868a0e3-097b-4ce5-9a31-85049d14dd19",
  CellID->197552022],
-Cell[43983, 1179, 2017, 66, 64, "Output",ExpressionUUID->"e3ef61d9-e7d6-dc4d-a6e9-32362d143f61",
+Cell[44038, 1179, 2017, 66, 64, "Output",ExpressionUUID->"e3ef61d9-e7d6-dc4d-a6e9-32362d143f61",
  CellID->484414763]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[46037, 1250, 737, 14, 43, "Input",ExpressionUUID->"a9959ce2-ba04-304e-99f7-ae75042c092e",
+Cell[46092, 1250, 737, 14, 43, "Input",ExpressionUUID->"a9959ce2-ba04-304e-99f7-ae75042c092e",
  CellID->156019331],
-Cell[46777, 1266, 1938, 62, 64, "Output",ExpressionUUID->"399a46f8-6eba-5747-964c-a136b103decd",
+Cell[46832, 1266, 1938, 62, 64, "Output",ExpressionUUID->"399a46f8-6eba-5747-964c-a136b103decd",
  CellID->288153693]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[48752, 1333, 671, 12, 43, "Input",ExpressionUUID->"e5e8ae42-115d-dd4c-8d2e-c7b0d9386bf0",
+Cell[48807, 1333, 671, 12, 43, "Input",ExpressionUUID->"e5e8ae42-115d-dd4c-8d2e-c7b0d9386bf0",
  CellID->657327319],
-Cell[49426, 1347, 3869, 102, 108, "Output",ExpressionUUID->"fdb9dbd0-c952-5d42-93d1-ea143256c897",
+Cell[49481, 1347, 3869, 102, 108, "Output",ExpressionUUID->"fdb9dbd0-c952-5d42-93d1-ea143256c897",
  CellID->121264892]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
-Cell[53334, 1454, 264, 5, 35, "ExampleSection",ExpressionUUID->"cdf3a0a8-61a8-4706-bba7-0936769630ac",
+Cell[53389, 1454, 264, 5, 35, "ExampleSection",ExpressionUUID->"cdf3a0a8-61a8-4706-bba7-0936769630ac",
  CellID->169069801],
 Cell[CellGroupData[{
-Cell[53623, 1463, 242, 5, 22, "ExampleSection",ExpressionUUID->"e8c7c6f4-434b-4367-8a6b-04cfe96eae91",
+Cell[53678, 1463, 242, 5, 23, "ExampleSection",ExpressionUUID->"e8c7c6f4-434b-4367-8a6b-04cfe96eae91",
  CellID->26616468],
 Cell[CellGroupData[{
-Cell[53890, 1472, 249, 5, 25, "ExampleSubsection",ExpressionUUID->"462d4f13-976b-4dd6-a5ee-020fb98a89d1",
+Cell[53945, 1472, 249, 5, 26, "ExampleSubsection",ExpressionUUID->"462d4f13-976b-4dd6-a5ee-020fb98a89d1",
  CellID->121447399],
-Cell[54142, 1479, 270, 5, 23, "ExampleText",ExpressionUUID->"6b353371-c9fb-4414-a3d4-34d156e3273b",
+Cell[54197, 1479, 270, 5, 24, "ExampleText",ExpressionUUID->"6b353371-c9fb-4414-a3d4-34d156e3273b",
  CellID->308716727],
 Cell[CellGroupData[{
-Cell[54437, 1488, 719, 16, 60, "Input",ExpressionUUID->"0330aad9-4cc1-48d7-b9ab-3b14d89c1a63",
+Cell[54492, 1488, 719, 16, 61, "Input",ExpressionUUID->"0330aad9-4cc1-48d7-b9ab-3b14d89c1a63",
  CellID->752120511],
-Cell[55159, 1506, 18803, 366, 53, "Output",ExpressionUUID->"2faa51d9-4c0b-4546-81c7-e4ebd8ec61d1",
+Cell[55214, 1506, 18803, 366, 53, "Output",ExpressionUUID->"2faa51d9-4c0b-4546-81c7-e4ebd8ec61d1",
  CellID->104387430]
 }, Open  ]],
-Cell[73977, 1875, 194, 2, 23, "ExampleText",ExpressionUUID->"dc5f0357-caca-4016-a189-488315e88afd",
+Cell[74032, 1875, 194, 2, 24, "ExampleText",ExpressionUUID->"dc5f0357-caca-4016-a189-488315e88afd",
  CellID->614277478],
 Cell[CellGroupData[{
-Cell[74196, 1881, 333, 8, 25, "Input",ExpressionUUID->"174c5153-60a6-4cda-904a-2dfdb3f26a24",
+Cell[74251, 1881, 333, 8, 25, "Input",ExpressionUUID->"174c5153-60a6-4cda-904a-2dfdb3f26a24",
  CellID->61126152],
-Cell[74532, 1891, 327, 7, 23, "Output",ExpressionUUID->"db28bc47-c84b-44b1-8241-2ca3598aa2af",
+Cell[74587, 1891, 327, 7, 24, "Output",ExpressionUUID->"db28bc47-c84b-44b1-8241-2ca3598aa2af",
  CellID->1456555431]
 }, Open  ]],
-Cell[74874, 1901, 310, 6, 40, "ExampleText",ExpressionUUID->"1b0a8ce4-b0eb-4787-91ad-507a428ac76e",
+Cell[74929, 1901, 310, 6, 41, "ExampleText",ExpressionUUID->"1b0a8ce4-b0eb-4787-91ad-507a428ac76e",
  CellID->443568370],
 Cell[CellGroupData[{
-Cell[75209, 1911, 331, 8, 25, "Input",ExpressionUUID->"a14cd146-f823-4bcb-af45-3132c230598e",
+Cell[75264, 1911, 331, 8, 25, "Input",ExpressionUUID->"a14cd146-f823-4bcb-af45-3132c230598e",
  CellID->194865256],
-Cell[75543, 1921, 487, 9, 25, "Message",ExpressionUUID->"796dd53d-0d66-4653-bce0-2bf5d2ed1f92",
+Cell[75598, 1921, 487, 9, 26, "Message",ExpressionUUID->"796dd53d-0d66-4653-bce0-2bf5d2ed1f92",
  CellID->1648489289],
-Cell[76033, 1932, 446, 11, 27, "Output",ExpressionUUID->"49ffb29f-cb16-473b-831a-17016fd45619",
+Cell[76088, 1932, 446, 11, 28, "Output",ExpressionUUID->"49ffb29f-cb16-473b-831a-17016fd45619",
  CellID->1472950276]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[76516, 1948, 241, 5, 18, "ExampleDelimiter",ExpressionUUID->"5d74a340-6917-447c-87c5-bf0565f3cb6d",
+Cell[76571, 1948, 241, 5, 20, "ExampleDelimiter",ExpressionUUID->"5d74a340-6917-447c-87c5-bf0565f3cb6d",
  CellID->99302603],
-Cell[76760, 1955, 240, 4, 23, "ExampleText",ExpressionUUID->"3a07e4a7-78c9-4d8c-b8cc-7073838b61bd",
+Cell[76815, 1955, 240, 4, 24, "ExampleText",ExpressionUUID->"3a07e4a7-78c9-4d8c-b8cc-7073838b61bd",
  CellID->9372414],
 Cell[CellGroupData[{
-Cell[77025, 1963, 942, 20, 60, "Input",ExpressionUUID->"b03d019e-4359-4091-b258-ea18cb660537",
+Cell[77080, 1963, 942, 20, 61, "Input",ExpressionUUID->"b03d019e-4359-4091-b258-ea18cb660537",
  CellID->463466769],
-Cell[77970, 1985, 18731, 360, 53, "Output",ExpressionUUID->"41c93f36-298d-49f7-abed-d8cbe4c1bbc1",
+Cell[78025, 1985, 18731, 360, 53, "Output",ExpressionUUID->"41c93f36-298d-49f7-abed-d8cbe4c1bbc1",
  CellID->1877422799]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[96762, 2352, 318, 6, 25, "ExampleSubsection",ExpressionUUID->"2c3516bc-e810-497e-a746-01cd87a15bed",
+Cell[96817, 2352, 318, 6, 26, "ExampleSubsection",ExpressionUUID->"2c3516bc-e810-497e-a746-01cd87a15bed",
  CellID->278998831],
-Cell[97083, 2360, 246, 4, 23, "ExampleText",ExpressionUUID->"a279445f-da19-4b21-9ece-ae57b1aaa295",
+Cell[97138, 2360, 246, 4, 24, "ExampleText",ExpressionUUID->"a279445f-da19-4b21-9ece-ae57b1aaa295",
  CellID->298208290],
 Cell[CellGroupData[{
-Cell[97354, 2368, 692, 16, 43, "Input",ExpressionUUID->"2ad7185a-8710-43ab-8ae0-ca505573c97b",
+Cell[97409, 2368, 692, 16, 43, "Input",ExpressionUUID->"2ad7185a-8710-43ab-8ae0-ca505573c97b",
  CellID->70406071],
-Cell[98049, 2386, 1318, 33, 46, "Output",ExpressionUUID->"85dacf1e-98c6-47b8-891a-ff68170add43",
+Cell[98104, 2386, 1318, 33, 47, "Output",ExpressionUUID->"85dacf1e-98c6-47b8-891a-ff68170add43",
  CellID->2007244601]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[99416, 2425, 316, 6, 25, "ExampleSubsection",ExpressionUUID->"738ff956-e91d-43b0-9e73-fba9256bae54",
+Cell[99471, 2425, 316, 6, 26, "ExampleSubsection",ExpressionUUID->"738ff956-e91d-43b0-9e73-fba9256bae54",
  CellID->251832688],
-Cell[99735, 2433, 591, 12, 40, "ExampleText",ExpressionUUID->"cc0bbb2b-5d55-4bad-97f8-002b8a309462",
+Cell[99790, 2433, 591, 12, 43, "ExampleText",ExpressionUUID->"cc0bbb2b-5d55-4bad-97f8-002b8a309462",
  CellID->270948873],
 Cell[CellGroupData[{
-Cell[100351, 2449, 635, 14, 43, "Input",ExpressionUUID->"e6de82df-bb63-4cb2-880e-d02c5a3d3e5c",
+Cell[100406, 2449, 635, 14, 43, "Input",ExpressionUUID->"e6de82df-bb63-4cb2-880e-d02c5a3d3e5c",
  CellID->676638745],
-Cell[100989, 2465, 255, 6, 23, "Output",ExpressionUUID->"863e7bc8-08f6-4508-8ed7-57b6a1cda360",
+Cell[101044, 2465, 255, 6, 24, "Output",ExpressionUUID->"863e7bc8-08f6-4508-8ed7-57b6a1cda360",
  CellID->993954032]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[101293, 2477, 317, 6, 25, "ExampleSubsection",ExpressionUUID->"2683c412-3ef8-46ce-ae2c-bfe94c1137cb",
+Cell[101348, 2477, 317, 6, 26, "ExampleSubsection",ExpressionUUID->"2683c412-3ef8-46ce-ae2c-bfe94c1137cb",
  CellID->200887691],
-Cell[101613, 2485, 276, 5, 23, "ExampleText",ExpressionUUID->"b8e899f4-7b7e-4eb6-a9c2-bf3e4adac288",
+Cell[101668, 2485, 276, 5, 24, "ExampleText",ExpressionUUID->"b8e899f4-7b7e-4eb6-a9c2-bf3e4adac288",
  CellID->654805157],
 Cell[CellGroupData[{
-Cell[101914, 2494, 1864, 47, 165, "Input",ExpressionUUID->"a616c325-ab33-4119-9ddc-a86d79028566",
+Cell[101969, 2494, 1864, 47, 166, "Input",ExpressionUUID->"a616c325-ab33-4119-9ddc-a86d79028566",
  CellID->1148403],
-Cell[103781, 2543, 3867, 102, 108, "Output",ExpressionUUID->"de9567f6-fe5b-f74f-91ea-38e763a02f28",
+Cell[103836, 2543, 3867, 102, 108, "Output",ExpressionUUID->"de9567f6-fe5b-f74f-91ea-38e763a02f28",
  CellID->374543594]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
-Cell[107687, 2650, 248, 5, 35, "ExampleSection",ExpressionUUID->"5d9c66a9-2524-477e-bda4-777d86e71207",
+Cell[107742, 2650, 248, 5, 35, "ExampleSection",ExpressionUUID->"5d9c66a9-2524-477e-bda4-777d86e71207",
  CellID->317484403],
-Cell[107938, 2657, 258, 5, 22, "ExampleSection",ExpressionUUID->"b34fadbf-53bf-4c0f-a2c9-b944d3b156e0",
+Cell[CellGroupData[{
+Cell[108015, 2659, 258, 5, 23, "ExampleSection",ExpressionUUID->"b34fadbf-53bf-4c0f-a2c9-b944d3b156e0",
  CellID->298852093],
-Cell[108199, 2664, 251, 5, 22, "ExampleSection",ExpressionUUID->"6f8a9891-1da3-4c2a-8d54-2a23b4e48ef2",
+Cell[CellGroupData[{
+Cell[108298, 2668, 767, 14, 28, "ExampleSubsection",ExpressionUUID->"3390a96f-2b13-6344-bd3a-88875f42664b",
+ CellID->296669070],
+Cell[109068, 2684, 1499, 25, 60, "ExampleText",ExpressionUUID->"fd9c54f6-8d5c-7445-b2b0-bc2558b8ccf2",
+ CellID->105689035],
+Cell[110570, 2711, 1559, 26, 41, "ExampleText",ExpressionUUID->"4ab5a89f-9424-804a-bb1e-f3525396ee30",
+ CellID->709734105],
+Cell[112132, 2739, 1444, 28, 77, "ExampleText",ExpressionUUID->"25a88263-624f-9044-b7e9-ffa7d3ad2143",
+ CellID->105347582],
+Cell[CellGroupData[{
+Cell[113601, 2771, 2368, 53, 159, "Input",ExpressionUUID->"b72970c2-2e03-194e-a886-48306db9e1fe",
+ CellID->448289478],
+Cell[115972, 2826, 2925, 69, 67, "Output",ExpressionUUID->"ee3e6619-0aca-4645-8fcc-15c0257fb24c",
+ CellID->54729281]
+}, Open  ]],
+Cell[118912, 2898, 1012, 15, 58, "ExampleText",ExpressionUUID->"8426917f-e9a1-9b4a-b254-015f536580c5",
+ CellID->135010306],
+Cell[119927, 2915, 1301, 20, 58, "ExampleText",ExpressionUUID->"353ad895-6faf-2643-85a6-a8331bb20202",
+ CellID->359104851]
+}, Open  ]]
+}, Open  ]],
+Cell[121255, 2939, 251, 5, 35, "ExampleSection",ExpressionUUID->"6f8a9891-1da3-4c2a-8d54-2a23b4e48ef2",
  CellID->221762665],
-Cell[108453, 2671, 256, 5, 22, "ExampleSection",ExpressionUUID->"0ae43145-54ab-47b0-853b-c06f35087266",
+Cell[121509, 2946, 256, 5, 23, "ExampleSection",ExpressionUUID->"0ae43145-54ab-47b0-853b-c06f35087266",
  CellID->194169788],
-Cell[108712, 2678, 249, 5, 22, "ExampleSection",ExpressionUUID->"df11dd4a-6677-4027-850d-81be8390d86e",
+Cell[121768, 2953, 249, 5, 23, "ExampleSection",ExpressionUUID->"df11dd4a-6677-4027-850d-81be8390d86e",
  CellID->205778757]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[108998, 2688, 110, 1, 71, "MetadataSection",ExpressionUUID->"f42a207b-c1a5-4b72-bffd-171b7c78e43a",
+Cell[122054, 2963, 110, 1, 72, "MetadataSection",ExpressionUUID->"f42a207b-c1a5-4b72-bffd-171b7c78e43a",
  CellID->892947207],
-Cell[109111, 2691, 474, 12, 25, "History",ExpressionUUID->"043659d4-bd7a-41e3-8d6d-5096845cfc0e",
+Cell[122167, 2966, 474, 12, 26, "History",ExpressionUUID->"043659d4-bd7a-41e3-8d6d-5096845cfc0e",
  CellID->5319953],
 Cell[CellGroupData[{
-Cell[109610, 2707, 483, 13, 20, "CategorizationSection",ExpressionUUID->"f42be207-fac4-45ff-9b65-f94b8dd6fd9f",
+Cell[122666, 2982, 483, 13, 21, "CategorizationSection",ExpressionUUID->"f42be207-fac4-45ff-9b65-f94b8dd6fd9f",
  CellID->99447318],
-Cell[110096, 2722, 134, 2, 34, "Categorization",ExpressionUUID->"c778a203-35fe-4567-93f1-8c6b1bcd183f",
+Cell[123152, 2997, 134, 2, 34, "Categorization",ExpressionUUID->"c778a203-35fe-4567-93f1-8c6b1bcd183f",
  CellID->280483579],
-Cell[110233, 2726, 159, 2, 34, "Categorization",ExpressionUUID->"2a039ea4-f2c3-46b2-9d95-f31ba7977b39",
+Cell[123289, 3001, 159, 2, 34, "Categorization",ExpressionUUID->"2a039ea4-f2c3-46b2-9d95-f31ba7977b39",
  CellID->513088406],
-Cell[110395, 2730, 156, 2, 34, "Categorization",ExpressionUUID->"1a707789-5b23-4dca-b002-5ed992e7c839",
+Cell[123451, 3005, 156, 2, 34, "Categorization",ExpressionUUID->"1a707789-5b23-4dca-b002-5ed992e7c839",
  CellID->424615657],
-Cell[110554, 2734, 268, 5, 34, "Categorization",ExpressionUUID->"a1b1c2fc-53fa-431d-a0fe-f18cd23daaba",
+Cell[123610, 3009, 268, 5, 34, "Categorization",ExpressionUUID->"a1b1c2fc-53fa-431d-a0fe-f18cd23daaba",
  CellID->324277285]
 }, Closed]],
 Cell[CellGroupData[{
-Cell[110859, 2744, 110, 1, 20, "KeywordsSection",ExpressionUUID->"37f42972-c976-465c-86ba-9ab841d611b5",
+Cell[123915, 3019, 110, 1, 21, "KeywordsSection",ExpressionUUID->"37f42972-c976-465c-86ba-9ab841d611b5",
  CellID->157024413],
-Cell[110972, 2747, 99, 1, 20, "Keywords",ExpressionUUID->"b50ec6a9-d57d-4e72-b445-88cf73b961f7",
+Cell[124028, 3022, 99, 1, 20, "Keywords",ExpressionUUID->"b50ec6a9-d57d-4e72-b445-88cf73b961f7",
  CellID->369608981]
 }, Closed]],
 Cell[CellGroupData[{
-Cell[111108, 2753, 118, 1, 20, "TemplatesSection",ExpressionUUID->"7ad12944-0259-4015-87e6-e35907a9425a",
+Cell[124164, 3028, 118, 1, 21, "TemplatesSection",ExpressionUUID->"7ad12944-0259-4015-87e6-e35907a9425a",
  CellID->30111239],
-Cell[111229, 2756, 148, 2, 27, "Template",ExpressionUUID->"73cd4a0a-b323-440e-aafa-198f5e56a0cd",
+Cell[124285, 3031, 148, 2, 27, "Template",ExpressionUUID->"73cd4a0a-b323-440e-aafa-198f5e56a0cd",
  CellID->212216560],
-Cell[111380, 2760, 137, 2, 27, "Template",ExpressionUUID->"954f59e2-12e7-4b48-89ad-b7e99ee0344d",
+Cell[124436, 3035, 137, 2, 27, "Template",ExpressionUUID->"954f59e2-12e7-4b48-89ad-b7e99ee0344d",
  CellID->393173875],
-Cell[111520, 2764, 135, 2, 27, "Template",ExpressionUUID->"5a4f48b7-d6e5-4ac6-a99d-27c2b08ba3a6",
+Cell[124576, 3039, 135, 2, 27, "Template",ExpressionUUID->"5a4f48b7-d6e5-4ac6-a99d-27c2b08ba3a6",
  CellID->140031180],
-Cell[111658, 2768, 136, 2, 27, "Template",ExpressionUUID->"ea191618-1ca8-4fd2-b80f-eeec0e7640b0",
+Cell[124714, 3043, 136, 2, 27, "Template",ExpressionUUID->"ea191618-1ca8-4fd2-b80f-eeec0e7640b0",
  CellID->94782372]
 }, Closed]]
 }, Open  ]]

--- a/Paclet/Documentation/English/ReferencePages/Symbols/NonReciprocalAbelianBlochHamiltonian.nb
+++ b/Paclet/Documentation/English/ReferencePages/Symbols/NonReciprocalAbelianBlochHamiltonian.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[    139628,       3365]
-NotebookOptionsPosition[    124878,       3049]
-NotebookOutlinePosition[    125684,       3075]
-CellTagsIndexPosition[    125603,       3070]
+NotebookDataLength[    144163,       3477]
+NotebookOptionsPosition[    129055,       3155]
+NotebookOutlinePosition[    129862,       3181]
+CellTagsIndexPosition[    129781,       3176]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -191,30 +191,134 @@ Cell[TextData[{
  "The hoppings opposite to the canonical direction are specified by ",
  Cell[BoxData[
   StyleBox["hoppingsOpposite", "TI"]], "InlineFormula",ExpressionUUID->
-  "0e75aa3f-fd62-e84f-b577-622afdaf3d2d"],
+  "9b3d1f85-a3dd-df46-a169-5cff115c2a65"],
  " : for any edge ",
  StyleBox["e", "InlineCode"],
  " of ",
  Cell[BoxData[
   RowBox[{
    StyleBox["mgraph", "TI"], "[", "\"\<Graph\>\"", "]"}]], "InlineFormula",
-  ExpressionUUID->"ac51201d-cf47-014c-9d48-05393d9fb0b9"],
+  ExpressionUUID->"85e4b00f-e027-1147-a4bb-4f548a130801"],
  ", ",
  Cell[BoxData[
   StyleBox["hoppingsOpposite", "TI"]], "InlineFormula",ExpressionUUID->
-  "c188b50d-a3ee-314a-acf5-b2780fd571e2"],
+  "d9681b5a-3b5a-7846-a523-e73ae6f92355"],
  StyleBox["[e]", "InlineCode"],
  " must evaluate to the hopping matrix for the orbitals associated with that \
 edge or a number if ",
  Cell[BoxData[
   StyleBox["norb", "TI"]], "InlineFormula",ExpressionUUID->
-  "9f9dbe9c-ffc1-a846-917d-7b828657cd3a"],
+  "d219ab21-9b16-2a4f-ad48-ea83af26366f"],
  StyleBox["=1", "InlineCode"],
  "."
 }], "Notes",
- CellChangeTimes->{{3.9344721305933867`*^9, 3.9344721565686007`*^9}, {
-  3.9374205340469913`*^9, 3.9374205447197323`*^9}},
- CellID->129485177,ExpressionUUID->"cc066a5d-5957-114e-8575-a4943c1051fb"],
+ CellChangeTimes->{{3.959400338360874*^9, 3.959400611826578*^9}, {
+  3.959400775550457*^9, 3.959400812953228*^9}, {3.959401402881895*^9, 
+  3.959401654388151*^9}, {3.959401823738619*^9, 3.9594018421608505`*^9}, {
+  3.959401886468996*^9, 3.959401888325199*^9}},
+ CellID->157982633,ExpressionUUID->"48d2991f-d268-794b-a96d-3173ea2a12fa"],
+
+Cell[TextData[{
+ "For multi-orbital models with ",
+ Cell[BoxData[
+  StyleBox["norb", "TI"]], "InlineFormula",ExpressionUUID->
+  "81b0da3b-a9eb-b54b-9ea9-e5146bf8a591"],
+ "\[NotEqual]",
+ StyleBox["1", "InlineCode"],
+ ", the specification of the hopping matrix for the hopping amplitudes  ",
+ Cell[BoxData[
+  StyleBox["hoppingsOpposite", "TI"]], "InlineFormula",ExpressionUUID->
+  "98b9137c-2224-f348-ad01-f9dff9558df5"],
+ " need to follow the same assignment conventions as the hopping amplitudes \
+",
+ Cell[BoxData[
+  StyleBox["hoppingsCanonical", "TI"]], "InlineFormula",ExpressionUUID->
+  "fa818acb-4a13-a641-8b3e-c4d797f7fc46"],
+ ". In order to illustrate the used convention it is instructive to consider \
+a general two-orbital ",
+ StyleBox["{p,q}", "InlineCode"],
+ "-lattice model with nearest-neighbor interactions on an arbitrary unit cell \
+with two sites. Consider the two sites ",
+ StyleBox["i", "InlineCode"],
+ " and ",
+ StyleBox["j", "InlineCode"],
+ " in a unit cell, each equipped with two orbitals ",
+ StyleBox["a", "InlineCode"],
+ " and ",
+ StyleBox["b", "InlineCode"],
+ ". Further, let a hopping in the canonical direction be defined as ",
+ StyleBox["i", "InlineCode"],
+ " \[Rule] ",
+ StyleBox["j,", "InlineCode"],
+ " and ",
+ StyleBox["j", "InlineCode"],
+ " \[Rule] ",
+ StyleBox["i", "InlineCode"],
+ " in the opposite direction. The following hopping matrices need to be \
+specified, where each matrix entry specifies the corresponding hopping \
+amplitudes between corresponding pairs of orbitals:"
+}], "Notes",
+ CellChangeTimes->{{3.959416241755583*^9, 3.959416242459528*^9}, {
+   3.9594167264317684`*^9, 3.959416768108032*^9}, {3.959417246453047*^9, 
+   3.9594172834939194`*^9}, 3.9594174076191235`*^9, {3.9594180058355064`*^9, 
+   3.9594180491644745`*^9}, {3.9594184160936623`*^9, 3.959418652769972*^9}, {
+   3.9594186847437496`*^9, 3.9594187085016575`*^9}, {3.9594187469976215`*^9, 
+   3.959418815211241*^9}, {3.959419067188925*^9, 3.959419090362995*^9}, {
+   3.9594205426341953`*^9, 3.9594205767974167`*^9}},
+ CellID->311370265,ExpressionUUID->"4b29621e-e5a1-014b-ac6b-2794c9594036"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{
+   RowBox[{"hoppingsCanonical", "=", 
+    RowBox[{
+     RowBox[{"(", GridBox[{
+        {
+         RowBox[{
+          SubscriptBox["a", "i"], "\[Rule]", 
+          SubscriptBox["a", "j"]}], 
+         RowBox[{
+          SubscriptBox["a", "i"], "\[Rule]", 
+          SubscriptBox["b", "j"]}]},
+        {
+         RowBox[{
+          SubscriptBox["b", "i"], "\[Rule]", 
+          SubscriptBox["b", "j"]}], 
+         RowBox[{
+          SubscriptBox["b", "i"], "\[Rule]", 
+          SubscriptBox["b", "j"]}]}
+       }], ")"}], "&"}]}], ";"}], " "}]], "Notes",
+ CellChangeTimes->{{3.9594190921442356`*^9, 3.9594191869209785`*^9}, {
+   3.9594199305607395`*^9, 3.959419942131056*^9}, 3.9594199844307747`*^9, {
+   3.959420111086876*^9, 3.9594201114812164`*^9}, 3.959420152732893*^9},
+ CellID->207376718,ExpressionUUID->"fe1ae727-78d3-fa45-9ae6-a294808aa9bd"],
+
+Cell[TextData[Cell[BoxData[
+ RowBox[{
+  RowBox[{"hoppingsOpposite", "=", 
+   RowBox[{
+    RowBox[{"(", GridBox[{
+       {
+        RowBox[{
+         SubscriptBox["a", "i"], "\[LeftArrow]", 
+         SubscriptBox["a", "j"]}], 
+        RowBox[{
+         SubscriptBox["a", "i"], "\[LeftArrow]", 
+         SubscriptBox["b", "j"]}]},
+       {
+        RowBox[{
+         SubscriptBox["b", "i"], "\[LeftArrow]", 
+         SubscriptBox["b", "j"]}], 
+        RowBox[{
+         SubscriptBox["b", "i"], "\[LeftArrow]", 
+         SubscriptBox["b", "j"]}]}
+      }], ")"}], "&"}]}], ";"}]],
+ CellChangeTimes->{{3.9594190921442356`*^9, 3.9594191869209785`*^9}, {
+  3.9594199305607395`*^9, 
+  3.959419942131056*^9}},ExpressionUUID->"2850798a-6068-5a4f-9261-\
+c718489a9cf0"]], "Notes",
+ CellChangeTimes->{{3.959420522251034*^9, 3.9594205393492985`*^9}},
+ CellID->396819643,ExpressionUUID->"cdf84976-5e92-3a49-b5fa-88dc4904df87"],
 
 Cell["The following options can be given:", "Notes",
  CellChangeTimes->{{3.906026854624065*^9, 3.9060268604382353`*^9}, 
@@ -1517,8 +1621,9 @@ Cell[BoxData[
              ButtonBox[
               DynamicBox[
                FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"], 
-               ImageSizeCache -> {12.018623046875, {0., 12.018623046875}}], 
-              Appearance -> None, BaseStyle -> {}, 
+               ImageSizeCache -> {
+                11.02578047277406, {0., 11.02578047277406}}], Appearance -> 
+              None, BaseStyle -> {}, 
               ButtonFunction :> (Typeset`open$$ = True), Evaluator -> 
               Automatic, Method -> "Preemptive"], 
              Alignment -> {Center, Center}, ImageSize -> 
@@ -1996,8 +2101,9 @@ Cell[BoxData[
              ButtonBox[
               DynamicBox[
                FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"], 
-               ImageSizeCache -> {12.018623046875, {0., 12.018623046875}}], 
-              Appearance -> None, BaseStyle -> {}, 
+               ImageSizeCache -> {
+                11.02578047277406, {0., 11.02578047277406}}], Appearance -> 
+              None, BaseStyle -> {}, 
               ButtonFunction :> (Typeset`open$$ = True), Evaluator -> 
               Automatic, Method -> "Preemptive"], 
              Alignment -> {Center, Center}, ImageSize -> 
@@ -2587,8 +2693,7 @@ Cell[BoxData[
           RowBox[{"4", "+", 
            RowBox[{"3", " ", 
             SuperscriptBox["\[ExponentialE]", 
-             RowBox[{"\[ImaginaryI]", " ", "k6"}]]}]}], ")"}]}]}]}], "}"}], 
-     ",", 
+             RowBox[{"\[ImaginaryI]", " ", "k6"}]]}]}], ")"}]}]}]}], "}"}], ",", 
      RowBox[{"{", 
       RowBox[{
        RowBox[{
@@ -2713,13 +2818,13 @@ Cell[TextData[{
  "To specify the hopping matrix for the hopping amplitudes  ",
  Cell[BoxData[
   StyleBox["hoppingsOpposite", "TI"]], "InlineFormula",ExpressionUUID->
-  "83bd0532-97da-f248-8b17-51a00579e4fb"],
+  "9ffed3b3-ad09-c245-87a6-17180f48149b"],
  " appropriately, the positions of the matrix entries for each pair of \
 orbitals is inherited from the hopping matrix ",
  Cell[BoxData[
   StyleBox["hoppingsCanonical", "TI"]], "InlineFormula",ExpressionUUID->
-  "9966380f-fb2b-ba4d-9f24-ab65e5d9d312"],
- ". "
+  "5f1747bb-5a3d-3142-9124-9da904578e2d"],
+ "."
 }], "ExampleText",
  CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
    3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
@@ -2734,7 +2839,8 @@ orbitals is inherited from the hopping matrix ",
    3.955170255833084*^9}, {3.955170301413376*^9, 3.9551703913169937`*^9}, {
    3.955170445563442*^9, 3.955170745103998*^9}, {3.95517080197999*^9, 
    3.955170813024542*^9}, {3.955171255916292*^9, 3.9551712615131607`*^9}, {
-   3.955172093403908*^9, 3.9551720938842525`*^9}},
+   3.955172093403908*^9, 3.9551720938842525`*^9}, {3.959403546360777*^9, 
+   3.959403556192663*^9}, {3.959420289637865*^9, 3.9594203091410427`*^9}},
  CellID->709734105,ExpressionUUID->"4ab5a89f-9424-804a-bb1e-f3525396ee30"],
 
 Cell[TextData[{
@@ -3050,8 +3156,8 @@ Cell[BoxData[""], "Template",
 WindowSize->{1269, 647},
 WindowMargins->{{0, Automatic}, {Automatic, 0}},
 TaggingRules-><|"Paclet" -> "PatrickMLenggenhager/HyperBloch"|>,
-Magnification:>1. Inherited,
-FrontEndVersion->"14.0 for Microsoft Windows (64-bit) (December 12, 2023)",
+Magnification:>1.1 Inherited,
+FrontEndVersion->"14.2 for Microsoft Windows (64-bit) (December 26, 2024)",
 StyleDefinitions->FrontEnd`FileName[{"Wolfram"}, "FunctionPageStylesExt.nb", 
   CharacterEncoding -> "UTF-8"],
 ExpressionUUID->"ca524783-33ba-4436-a7c7-e9b68abdb844"
@@ -3062,308 +3168,314 @@ ExpressionUUID->"ca524783-33ba-4436-a7c7-e9b68abdb844"
 (*CellTagsOutline
 CellTagsIndex->{
  "ExtendedExamples"->{
-  Cell[40537, 1080, 485, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"67ec221c-caf6-4173-ad73-9d17ddeabdd0",
+  Cell[44581, 1184, 485, 13, 62, "ExtendedExamplesSection",ExpressionUUID->"67ec221c-caf6-4173-ad73-9d17ddeabdd0",
    CellTags->"ExtendedExamples",
    CellID->9214842]}
  }
 *)
 (*CellTagsIndex
 CellTagsIndex->{
- {"ExtendedExamples", 125410, 3063}
+ {"ExtendedExamples", 129588, 3169}
  }
 *)
 (*NotebookFileOutline
 Notebook[{
 Cell[CellGroupData[{
-Cell[580, 22, 203, 2, 74, "ObjectName",ExpressionUUID->"153c8566-b789-49e1-9042-3899900e3b7a",
+Cell[580, 22, 203, 2, 79, "ObjectName",ExpressionUUID->"153c8566-b789-49e1-9042-3899900e3b7a",
  CellID->641622780],
-Cell[786, 26, 2695, 68, 134, "Usage",ExpressionUUID->"5a95bc6d-6279-4563-9d22-a21d53dda161",
+Cell[786, 26, 2695, 68, 141, "Usage",ExpressionUUID->"5a95bc6d-6279-4563-9d22-a21d53dda161",
  CellID->207877341],
-Cell[3484, 96, 1212, 30, 48, "Notes",ExpressionUUID->"67da8e43-b8f7-45d4-9e41-00f44a47cfbd",
+Cell[3484, 96, 1212, 30, 51, "Notes",ExpressionUUID->"67da8e43-b8f7-45d4-9e41-00f44a47cfbd",
  CellID->642025679],
-Cell[4699, 128, 1090, 28, 48, "Notes",ExpressionUUID->"51a2fb5a-fade-4a72-bf0c-9242b370fb83",
+Cell[4699, 128, 1090, 28, 51, "Notes",ExpressionUUID->"51a2fb5a-fade-4a72-bf0c-9242b370fb83",
  CellID->140612745],
-Cell[5792, 158, 1233, 29, 69, "Notes",ExpressionUUID->"797360d4-9d4f-4c4d-ad1f-4f20b1a66ee0",
+Cell[5792, 158, 1233, 29, 73, "Notes",ExpressionUUID->"797360d4-9d4f-4c4d-ad1f-4f20b1a66ee0",
  CellID->258865958],
-Cell[7028, 189, 1073, 27, 69, "Notes",ExpressionUUID->"cc066a5d-5957-114e-8575-a4943c1051fb",
- CellID->129485177],
-Cell[8104, 218, 223, 3, 27, "Notes",ExpressionUUID->"916d2e20-f426-4271-9d7c-a98609af83a2",
+Cell[7028, 189, 1211, 29, 73, "Notes",ExpressionUUID->"48d2991f-d268-794b-a96d-3173ea2a12fa",
+ CellID->157982633],
+Cell[8242, 220, 2105, 47, 172, "Notes",ExpressionUUID->"4b29621e-e5a1-014b-ac6b-2794c9594036",
+ CellID->311370265],
+Cell[10350, 269, 882, 24, 45, "Notes",ExpressionUUID->"fe1ae727-78d3-fa45-9ae6-a294808aa9bd",
+ CellID->207376718],
+Cell[11235, 295, 910, 25, 45, "Notes",ExpressionUUID->"cdf84976-5e92-3a49-b5fa-88dc4904df87",
+ CellID->396819643],
+Cell[12148, 322, 223, 3, 28, "Notes",ExpressionUUID->"916d2e20-f426-4271-9d7c-a98609af83a2",
  CellID->122405462],
-Cell[8330, 223, 2245, 48, 177, "3ColumnTableMod",ExpressionUUID->"d8fef008-55a1-4e3c-9331-a244f4fc957d",
+Cell[12374, 327, 2245, 48, 176, "3ColumnTableMod",ExpressionUUID->"d8fef008-55a1-4e3c-9331-a244f4fc957d",
  CellID->45544999],
-Cell[10578, 273, 494, 12, 28, "Notes",ExpressionUUID->"06107a60-30ae-4fb1-b3dc-d37ff9fca811",
+Cell[14622, 377, 494, 12, 28, "Notes",ExpressionUUID->"06107a60-30ae-4fb1-b3dc-d37ff9fca811",
  CellID->612325770],
-Cell[11075, 287, 1233, 28, 69, "Notes",ExpressionUUID->"4ee2233a-ed55-446d-b19b-d328dec0fa7d",
+Cell[15119, 391, 1233, 28, 70, "Notes",ExpressionUUID->"4ee2233a-ed55-446d-b19b-d328dec0fa7d",
  CellID->346090343]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[12345, 320, 435, 12, 40, "TechNotesSection",ExpressionUUID->"0fea9c94-dcc9-4460-b773-0032ab8ec549",
+Cell[16389, 424, 435, 12, 43, "TechNotesSection",ExpressionUUID->"0fea9c94-dcc9-4460-b773-0032ab8ec549",
  CellID->995312194],
-Cell[12783, 334, 265, 6, 19, "Tutorials",ExpressionUUID->"1928c8e7-a68c-46a0-8cba-0ffff1419b9e",
+Cell[16827, 438, 265, 6, 19, "Tutorials",ExpressionUUID->"1928c8e7-a68c-46a0-8cba-0ffff1419b9e",
  CellID->151400]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[13085, 345, 472, 13, 39, "RelatedLinksSection",ExpressionUUID->"fecb14cf-25fa-4a0c-9894-8ca8438f0be1",
+Cell[17129, 449, 472, 13, 42, "RelatedLinksSection",ExpressionUUID->"fecb14cf-25fa-4a0c-9894-8ca8438f0be1",
  CellID->202509145],
-Cell[13560, 360, 103, 1, 19, "RelatedLinks",ExpressionUUID->"79cdcc1a-2b16-4dc9-9e2d-fc7a3173b09d",
+Cell[17604, 464, 103, 1, 19, "RelatedLinks",ExpressionUUID->"79cdcc1a-2b16-4dc9-9e2d-fc7a3173b09d",
  CellID->144199850]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[13700, 366, 458, 13, 39, "SeeAlsoSection",ExpressionUUID->"050b63cf-bf1c-4662-94e7-626aec5d6b33",
+Cell[17744, 470, 458, 13, 42, "SeeAlsoSection",ExpressionUUID->"050b63cf-bf1c-4662-94e7-626aec5d6b33",
  CellID->223461721],
-Cell[14161, 381, 4479, 107, 62, "SeeAlso",ExpressionUUID->"dbc05f00-cfba-473e-bc6d-ca3adf85f088",
+Cell[18205, 485, 4479, 107, 56, "SeeAlso",ExpressionUUID->"dbc05f00-cfba-473e-bc6d-ca3adf85f088",
  CellID->381155944]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[18677, 493, 182, 2, 39, "MoreAboutSection",ExpressionUUID->"628c56fb-2a64-454a-afda-0c72e8b98f07",
+Cell[22721, 597, 182, 2, 41, "MoreAboutSection",ExpressionUUID->"628c56fb-2a64-454a-afda-0c72e8b98f07",
  CellID->31221473],
-Cell[18862, 497, 281, 6, 19, "MoreAbout",ExpressionUUID->"f716947c-4c12-47a4-9cff-f2a24ce82555",
+Cell[22906, 601, 281, 6, 19, "MoreAbout",ExpressionUUID->"f716947c-4c12-47a4-9cff-f2a24ce82555",
  CellID->542581366]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[19180, 508, 530, 14, 69, "ExamplesInitializationSection",ExpressionUUID->"d27dce01-6ac7-4a45-a9d6-0701f911e181",
+Cell[23224, 612, 530, 14, 75, "ExamplesInitializationSection",ExpressionUUID->"d27dce01-6ac7-4a45-a9d6-0701f911e181",
  CellID->428868112],
-Cell[19713, 524, 306, 5, 45, "ExampleInitialization",ExpressionUUID->"b9b2fab4-94b0-40ca-9b3a-2f0308baac5d",
+Cell[23757, 628, 306, 5, 49, "ExampleInitialization",ExpressionUUID->"b9b2fab4-94b0-40ca-9b3a-2f0308baac5d",
  CellID->127019986]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[20056, 534, 442, 12, 71, "PrimaryExamplesSection",ExpressionUUID->"d2f8cf66-026c-48d5-a784-375f28f06a2d",
+Cell[24100, 638, 442, 12, 76, "PrimaryExamplesSection",ExpressionUUID->"d2f8cf66-026c-48d5-a784-375f28f06a2d",
  CellID->287190428],
-Cell[20501, 548, 1033, 17, 77, "ExampleText",ExpressionUUID->"ebb1feb3-0056-4f70-a821-cb75db877955",
+Cell[24545, 652, 1033, 17, 78, "ExampleText",ExpressionUUID->"ebb1feb3-0056-4f70-a821-cb75db877955",
  CellID->82755364],
 Cell[CellGroupData[{
-Cell[21559, 569, 879, 17, 43, "Input",ExpressionUUID->"1801ac2d-56d7-4398-bb12-0df44e788296",
+Cell[25603, 673, 879, 17, 46, "Input",ExpressionUUID->"1801ac2d-56d7-4398-bb12-0df44e788296",
  CellID->2282893],
-Cell[22441, 588, 1250, 32, 28, "Output",ExpressionUUID->"d85b87b9-5ea5-e142-aa96-c5defb7f74a6",
+Cell[26485, 692, 1250, 32, 29, "Output",ExpressionUUID->"d85b87b9-5ea5-e142-aa96-c5defb7f74a6",
  CellID->358951349]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[23728, 625, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"922de4a1-c33d-4c53-8420-c637e7f021b3",
+Cell[27772, 729, 242, 5, 18, "ExampleDelimiter",ExpressionUUID->"922de4a1-c33d-4c53-8420-c637e7f021b3",
  CellID->359821871],
-Cell[23973, 632, 286, 4, 24, "ExampleText",ExpressionUUID->"d5d6071a-bed5-46eb-8714-d433cf53be67",
+Cell[28017, 736, 286, 4, 25, "ExampleText",ExpressionUUID->"d5d6071a-bed5-46eb-8714-d433cf53be67",
  CellID->36408547],
 Cell[CellGroupData[{
-Cell[24284, 640, 877, 18, 43, "Input",ExpressionUUID->"3866cf54-8397-470a-83a7-afd78dfcc355",
+Cell[28328, 744, 877, 18, 46, "Input",ExpressionUUID->"3866cf54-8397-470a-83a7-afd78dfcc355",
  CellID->633400500],
-Cell[25164, 660, 1518, 41, 47, "Output",ExpressionUUID->"200b00c8-9201-854c-8f51-7bbc82880d34",
+Cell[29208, 764, 1518, 41, 50, "Output",ExpressionUUID->"200b00c8-9201-854c-8f51-7bbc82880d34",
  CellID->597007231]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[26731, 707, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"91af1e5a-0ac3-4065-ada3-09c2fcae8951",
+Cell[30775, 811, 242, 5, 18, "ExampleDelimiter",ExpressionUUID->"91af1e5a-0ac3-4065-ada3-09c2fcae8951",
  CellID->677196106],
-Cell[26976, 714, 1465, 30, 79, "ExampleText",ExpressionUUID->"ec5d7117-2c96-4cd7-8c70-8feb237d9c1a",
+Cell[31020, 818, 1465, 30, 78, "ExampleText",ExpressionUUID->"ec5d7117-2c96-4cd7-8c70-8feb237d9c1a",
  CellID->680708440],
 Cell[CellGroupData[{
-Cell[28466, 748, 5169, 145, 310, "Input",ExpressionUUID->"85e83bbc-1b5b-4ac6-911c-21ee445d4a06",
+Cell[32510, 852, 5169, 145, 340, "Input",ExpressionUUID->"85e83bbc-1b5b-4ac6-911c-21ee445d4a06",
  CellID->262417576],
-Cell[33638, 895, 1425, 38, 47, "Output",ExpressionUUID->"b1c315d3-d6ca-9e46-a19e-45e561f5a488",
+Cell[37682, 999, 1425, 38, 50, "Output",ExpressionUUID->"b1c315d3-d6ca-9e46-a19e-45e561f5a488",
  CellID->238453336]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[35112, 939, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"91af2a9a-8d2e-4cc0-9108-b1a6077fc751",
+Cell[39156, 1043, 242, 5, 18, "ExampleDelimiter",ExpressionUUID->"91af2a9a-8d2e-4cc0-9108-b1a6077fc751",
  CellID->228953716],
-Cell[35357, 946, 1231, 24, 60, "ExampleText",ExpressionUUID->"fcdd41cc-dab8-4085-956b-4fbaead769ff",
+Cell[39401, 1050, 1231, 24, 60, "ExampleText",ExpressionUUID->"fcdd41cc-dab8-4085-956b-4fbaead769ff",
  CellID->16699796],
 Cell[CellGroupData[{
-Cell[36613, 974, 1576, 40, 159, "Input",ExpressionUUID->"4f1af21c-17c3-43e9-bcd5-c3315c7f5030",
+Cell[40657, 1078, 1576, 40, 174, "Input",ExpressionUUID->"4f1af21c-17c3-43e9-bcd5-c3315c7f5030",
  CellID->78835713],
-Cell[38192, 1016, 2284, 57, 67, "Output",ExpressionUUID->"a350b281-9026-a242-a927-5a1487fff681",
+Cell[42236, 1120, 2284, 57, 51, "Output",ExpressionUUID->"a350b281-9026-a242-a927-5a1487fff681",
  CellID->316316822]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[40537, 1080, 485, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"67ec221c-caf6-4173-ad73-9d17ddeabdd0",
+Cell[44581, 1184, 485, 13, 62, "ExtendedExamplesSection",ExpressionUUID->"67ec221c-caf6-4173-ad73-9d17ddeabdd0",
  CellTags->"ExtendedExamples",
  CellID->9214842],
 Cell[CellGroupData[{
-Cell[41047, 1097, 241, 5, 35, "ExampleSection",ExpressionUUID->"7926246e-3782-40ac-be88-4537478d26ce",
+Cell[45091, 1201, 241, 5, 35, "ExampleSection",ExpressionUUID->"7926246e-3782-40ac-be88-4537478d26ce",
  CellID->403151183],
 Cell[CellGroupData[{
-Cell[41313, 1106, 182, 2, 24, "ExampleSubsection",ExpressionUUID->"95a98044-a233-4544-9891-89bb53f5a862",
+Cell[45357, 1210, 182, 2, 25, "ExampleSubsection",ExpressionUUID->"95a98044-a233-4544-9891-89bb53f5a862",
  CellID->198501545],
-Cell[41498, 1110, 327, 6, 41, "ExampleText",ExpressionUUID->"57b954c0-b7e2-4f82-aadb-289efe4b7cba",
+Cell[45542, 1214, 327, 6, 43, "ExampleText",ExpressionUUID->"57b954c0-b7e2-4f82-aadb-289efe4b7cba",
  CellID->293180495],
-Cell[41828, 1118, 578, 14, 43, "Input",ExpressionUUID->"89618398-f380-475c-b7e4-e054099d4d43",
+Cell[45872, 1222, 578, 14, 46, "Input",ExpressionUUID->"89618398-f380-475c-b7e4-e054099d4d43",
  CellID->407621152],
 Cell[CellGroupData[{
-Cell[42431, 1136, 454, 10, 25, "Input",ExpressionUUID->"6caac9fb-623b-44e4-a9f7-b8e4a66a4a73",
+Cell[46475, 1240, 454, 10, 27, "Input",ExpressionUUID->"6caac9fb-623b-44e4-a9f7-b8e4a66a4a73",
  CellID->244028921],
-Cell[42888, 1148, 474, 10, 24, "Output",ExpressionUUID->"1eaf42c8-938e-6640-8167-cfe868768b18",
+Cell[46932, 1252, 474, 10, 26, "Output",ExpressionUUID->"1eaf42c8-938e-6640-8167-cfe868768b18",
  CellID->389831821]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[43399, 1163, 636, 14, 43, "Input",ExpressionUUID->"7868a0e3-097b-4ce5-9a31-85049d14dd19",
+Cell[47443, 1267, 636, 14, 46, "Input",ExpressionUUID->"7868a0e3-097b-4ce5-9a31-85049d14dd19",
  CellID->197552022],
-Cell[44038, 1179, 2017, 66, 64, "Output",ExpressionUUID->"e3ef61d9-e7d6-dc4d-a6e9-32362d143f61",
+Cell[48082, 1283, 2017, 66, 69, "Output",ExpressionUUID->"e3ef61d9-e7d6-dc4d-a6e9-32362d143f61",
  CellID->484414763]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[46092, 1250, 737, 14, 43, "Input",ExpressionUUID->"a9959ce2-ba04-304e-99f7-ae75042c092e",
+Cell[50136, 1354, 737, 14, 46, "Input",ExpressionUUID->"a9959ce2-ba04-304e-99f7-ae75042c092e",
  CellID->156019331],
-Cell[46832, 1266, 1938, 62, 64, "Output",ExpressionUUID->"399a46f8-6eba-5747-964c-a136b103decd",
+Cell[50876, 1370, 1938, 62, 69, "Output",ExpressionUUID->"399a46f8-6eba-5747-964c-a136b103decd",
  CellID->288153693]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[48807, 1333, 671, 12, 43, "Input",ExpressionUUID->"e5e8ae42-115d-dd4c-8d2e-c7b0d9386bf0",
+Cell[52851, 1437, 671, 12, 46, "Input",ExpressionUUID->"e5e8ae42-115d-dd4c-8d2e-c7b0d9386bf0",
  CellID->657327319],
-Cell[49481, 1347, 3869, 102, 108, "Output",ExpressionUUID->"fdb9dbd0-c952-5d42-93d1-ea143256c897",
+Cell[53525, 1451, 3869, 102, 118, "Output",ExpressionUUID->"fdb9dbd0-c952-5d42-93d1-ea143256c897",
  CellID->121264892]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
-Cell[53389, 1454, 264, 5, 35, "ExampleSection",ExpressionUUID->"cdf3a0a8-61a8-4706-bba7-0936769630ac",
+Cell[57433, 1558, 264, 5, 35, "ExampleSection",ExpressionUUID->"cdf3a0a8-61a8-4706-bba7-0936769630ac",
  CellID->169069801],
 Cell[CellGroupData[{
-Cell[53678, 1463, 242, 5, 23, "ExampleSection",ExpressionUUID->"e8c7c6f4-434b-4367-8a6b-04cfe96eae91",
+Cell[57722, 1567, 242, 5, 21, "ExampleSection",ExpressionUUID->"e8c7c6f4-434b-4367-8a6b-04cfe96eae91",
  CellID->26616468],
 Cell[CellGroupData[{
-Cell[53945, 1472, 249, 5, 26, "ExampleSubsection",ExpressionUUID->"462d4f13-976b-4dd6-a5ee-020fb98a89d1",
+Cell[57989, 1576, 249, 5, 25, "ExampleSubsection",ExpressionUUID->"462d4f13-976b-4dd6-a5ee-020fb98a89d1",
  CellID->121447399],
-Cell[54197, 1479, 270, 5, 24, "ExampleText",ExpressionUUID->"6b353371-c9fb-4414-a3d4-34d156e3273b",
+Cell[58241, 1583, 270, 5, 25, "ExampleText",ExpressionUUID->"6b353371-c9fb-4414-a3d4-34d156e3273b",
  CellID->308716727],
 Cell[CellGroupData[{
-Cell[54492, 1488, 719, 16, 61, "Input",ExpressionUUID->"0330aad9-4cc1-48d7-b9ab-3b14d89c1a63",
+Cell[58536, 1592, 719, 16, 66, "Input",ExpressionUUID->"0330aad9-4cc1-48d7-b9ab-3b14d89c1a63",
  CellID->752120511],
-Cell[55214, 1506, 18803, 366, 53, "Output",ExpressionUUID->"2faa51d9-4c0b-4546-81c7-e4ebd8ec61d1",
+Cell[59258, 1610, 18824, 367, 54, "Output",ExpressionUUID->"2faa51d9-4c0b-4546-81c7-e4ebd8ec61d1",
  CellID->104387430]
 }, Open  ]],
-Cell[74032, 1875, 194, 2, 24, "ExampleText",ExpressionUUID->"dc5f0357-caca-4016-a189-488315e88afd",
+Cell[78097, 1980, 194, 2, 25, "ExampleText",ExpressionUUID->"dc5f0357-caca-4016-a189-488315e88afd",
  CellID->614277478],
 Cell[CellGroupData[{
-Cell[74251, 1881, 333, 8, 25, "Input",ExpressionUUID->"174c5153-60a6-4cda-904a-2dfdb3f26a24",
+Cell[78316, 1986, 333, 8, 27, "Input",ExpressionUUID->"174c5153-60a6-4cda-904a-2dfdb3f26a24",
  CellID->61126152],
-Cell[74587, 1891, 327, 7, 24, "Output",ExpressionUUID->"db28bc47-c84b-44b1-8241-2ca3598aa2af",
+Cell[78652, 1996, 327, 7, 26, "Output",ExpressionUUID->"db28bc47-c84b-44b1-8241-2ca3598aa2af",
  CellID->1456555431]
 }, Open  ]],
-Cell[74929, 1901, 310, 6, 41, "ExampleText",ExpressionUUID->"1b0a8ce4-b0eb-4787-91ad-507a428ac76e",
+Cell[78994, 2006, 310, 6, 43, "ExampleText",ExpressionUUID->"1b0a8ce4-b0eb-4787-91ad-507a428ac76e",
  CellID->443568370],
 Cell[CellGroupData[{
-Cell[75264, 1911, 331, 8, 25, "Input",ExpressionUUID->"a14cd146-f823-4bcb-af45-3132c230598e",
+Cell[79329, 2016, 331, 8, 27, "Input",ExpressionUUID->"a14cd146-f823-4bcb-af45-3132c230598e",
  CellID->194865256],
-Cell[75598, 1921, 487, 9, 26, "Message",ExpressionUUID->"796dd53d-0d66-4653-bce0-2bf5d2ed1f92",
+Cell[79663, 2026, 487, 9, 22, "Message",ExpressionUUID->"796dd53d-0d66-4653-bce0-2bf5d2ed1f92",
  CellID->1648489289],
-Cell[76088, 1932, 446, 11, 28, "Output",ExpressionUUID->"49ffb29f-cb16-473b-831a-17016fd45619",
+Cell[80153, 2037, 446, 11, 29, "Output",ExpressionUUID->"49ffb29f-cb16-473b-831a-17016fd45619",
  CellID->1472950276]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[76571, 1948, 241, 5, 20, "ExampleDelimiter",ExpressionUUID->"5d74a340-6917-447c-87c5-bf0565f3cb6d",
+Cell[80636, 2053, 241, 5, 18, "ExampleDelimiter",ExpressionUUID->"5d74a340-6917-447c-87c5-bf0565f3cb6d",
  CellID->99302603],
-Cell[76815, 1955, 240, 4, 24, "ExampleText",ExpressionUUID->"3a07e4a7-78c9-4d8c-b8cc-7073838b61bd",
+Cell[80880, 2060, 240, 4, 25, "ExampleText",ExpressionUUID->"3a07e4a7-78c9-4d8c-b8cc-7073838b61bd",
  CellID->9372414],
 Cell[CellGroupData[{
-Cell[77080, 1963, 942, 20, 61, "Input",ExpressionUUID->"b03d019e-4359-4091-b258-ea18cb660537",
+Cell[81145, 2068, 942, 20, 66, "Input",ExpressionUUID->"b03d019e-4359-4091-b258-ea18cb660537",
  CellID->463466769],
-Cell[78025, 1985, 18731, 360, 53, "Output",ExpressionUUID->"41c93f36-298d-49f7-abed-d8cbe4c1bbc1",
+Cell[82090, 2090, 18752, 361, 54, "Output",ExpressionUUID->"41c93f36-298d-49f7-abed-d8cbe4c1bbc1",
  CellID->1877422799]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[96817, 2352, 318, 6, 26, "ExampleSubsection",ExpressionUUID->"2c3516bc-e810-497e-a746-01cd87a15bed",
+Cell[100903, 2458, 318, 6, 25, "ExampleSubsection",ExpressionUUID->"2c3516bc-e810-497e-a746-01cd87a15bed",
  CellID->278998831],
-Cell[97138, 2360, 246, 4, 24, "ExampleText",ExpressionUUID->"a279445f-da19-4b21-9ece-ae57b1aaa295",
+Cell[101224, 2466, 246, 4, 25, "ExampleText",ExpressionUUID->"a279445f-da19-4b21-9ece-ae57b1aaa295",
  CellID->298208290],
 Cell[CellGroupData[{
-Cell[97409, 2368, 692, 16, 43, "Input",ExpressionUUID->"2ad7185a-8710-43ab-8ae0-ca505573c97b",
+Cell[101495, 2474, 692, 16, 46, "Input",ExpressionUUID->"2ad7185a-8710-43ab-8ae0-ca505573c97b",
  CellID->70406071],
-Cell[98104, 2386, 1318, 33, 47, "Output",ExpressionUUID->"85dacf1e-98c6-47b8-891a-ff68170add43",
+Cell[102190, 2492, 1318, 33, 50, "Output",ExpressionUUID->"85dacf1e-98c6-47b8-891a-ff68170add43",
  CellID->2007244601]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[99471, 2425, 316, 6, 26, "ExampleSubsection",ExpressionUUID->"738ff956-e91d-43b0-9e73-fba9256bae54",
+Cell[103557, 2531, 316, 6, 25, "ExampleSubsection",ExpressionUUID->"738ff956-e91d-43b0-9e73-fba9256bae54",
  CellID->251832688],
-Cell[99790, 2433, 591, 12, 43, "ExampleText",ExpressionUUID->"cc0bbb2b-5d55-4bad-97f8-002b8a309462",
+Cell[103876, 2539, 591, 12, 43, "ExampleText",ExpressionUUID->"cc0bbb2b-5d55-4bad-97f8-002b8a309462",
  CellID->270948873],
 Cell[CellGroupData[{
-Cell[100406, 2449, 635, 14, 43, "Input",ExpressionUUID->"e6de82df-bb63-4cb2-880e-d02c5a3d3e5c",
+Cell[104492, 2555, 635, 14, 46, "Input",ExpressionUUID->"e6de82df-bb63-4cb2-880e-d02c5a3d3e5c",
  CellID->676638745],
-Cell[101044, 2465, 255, 6, 24, "Output",ExpressionUUID->"863e7bc8-08f6-4508-8ed7-57b6a1cda360",
+Cell[105130, 2571, 255, 6, 26, "Output",ExpressionUUID->"863e7bc8-08f6-4508-8ed7-57b6a1cda360",
  CellID->993954032]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[101348, 2477, 317, 6, 26, "ExampleSubsection",ExpressionUUID->"2683c412-3ef8-46ce-ae2c-bfe94c1137cb",
+Cell[105434, 2583, 317, 6, 25, "ExampleSubsection",ExpressionUUID->"2683c412-3ef8-46ce-ae2c-bfe94c1137cb",
  CellID->200887691],
-Cell[101668, 2485, 276, 5, 24, "ExampleText",ExpressionUUID->"b8e899f4-7b7e-4eb6-a9c2-bf3e4adac288",
+Cell[105754, 2591, 276, 5, 25, "ExampleText",ExpressionUUID->"b8e899f4-7b7e-4eb6-a9c2-bf3e4adac288",
  CellID->654805157],
 Cell[CellGroupData[{
-Cell[101969, 2494, 1864, 47, 166, "Input",ExpressionUUID->"a616c325-ab33-4119-9ddc-a86d79028566",
+Cell[106055, 2600, 1864, 47, 182, "Input",ExpressionUUID->"a616c325-ab33-4119-9ddc-a86d79028566",
  CellID->1148403],
-Cell[103836, 2543, 3867, 102, 108, "Output",ExpressionUUID->"de9567f6-fe5b-f74f-91ea-38e763a02f28",
+Cell[107922, 2649, 3861, 101, 118, "Output",ExpressionUUID->"de9567f6-fe5b-f74f-91ea-38e763a02f28",
  CellID->374543594]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
-Cell[107742, 2650, 248, 5, 35, "ExampleSection",ExpressionUUID->"5d9c66a9-2524-477e-bda4-777d86e71207",
+Cell[111822, 2755, 248, 5, 35, "ExampleSection",ExpressionUUID->"5d9c66a9-2524-477e-bda4-777d86e71207",
  CellID->317484403],
 Cell[CellGroupData[{
-Cell[108015, 2659, 258, 5, 23, "ExampleSection",ExpressionUUID->"b34fadbf-53bf-4c0f-a2c9-b944d3b156e0",
+Cell[112095, 2764, 258, 5, 21, "ExampleSection",ExpressionUUID->"b34fadbf-53bf-4c0f-a2c9-b944d3b156e0",
  CellID->298852093],
 Cell[CellGroupData[{
-Cell[108298, 2668, 767, 14, 28, "ExampleSubsection",ExpressionUUID->"3390a96f-2b13-6344-bd3a-88875f42664b",
+Cell[112378, 2773, 767, 14, 25, "ExampleSubsection",ExpressionUUID->"3390a96f-2b13-6344-bd3a-88875f42664b",
  CellID->296669070],
-Cell[109068, 2684, 1499, 25, 60, "ExampleText",ExpressionUUID->"fd9c54f6-8d5c-7445-b2b0-bc2558b8ccf2",
+Cell[113148, 2789, 1499, 25, 60, "ExampleText",ExpressionUUID->"fd9c54f6-8d5c-7445-b2b0-bc2558b8ccf2",
  CellID->105689035],
-Cell[110570, 2711, 1559, 26, 41, "ExampleText",ExpressionUUID->"4ab5a89f-9424-804a-bb1e-f3525396ee30",
+Cell[114650, 2816, 1656, 27, 43, "ExampleText",ExpressionUUID->"4ab5a89f-9424-804a-bb1e-f3525396ee30",
  CellID->709734105],
-Cell[112132, 2739, 1444, 28, 77, "ExampleText",ExpressionUUID->"25a88263-624f-9044-b7e9-ffa7d3ad2143",
+Cell[116309, 2845, 1444, 28, 78, "ExampleText",ExpressionUUID->"25a88263-624f-9044-b7e9-ffa7d3ad2143",
  CellID->105347582],
 Cell[CellGroupData[{
-Cell[113601, 2771, 2368, 53, 159, "Input",ExpressionUUID->"b72970c2-2e03-194e-a886-48306db9e1fe",
+Cell[117778, 2877, 2368, 53, 174, "Input",ExpressionUUID->"b72970c2-2e03-194e-a886-48306db9e1fe",
  CellID->448289478],
-Cell[115972, 2826, 2925, 69, 67, "Output",ExpressionUUID->"ee3e6619-0aca-4645-8fcc-15c0257fb24c",
+Cell[120149, 2932, 2925, 69, 73, "Output",ExpressionUUID->"ee3e6619-0aca-4645-8fcc-15c0257fb24c",
  CellID->54729281]
 }, Open  ]],
-Cell[118912, 2898, 1012, 15, 58, "ExampleText",ExpressionUUID->"8426917f-e9a1-9b4a-b254-015f536580c5",
+Cell[123089, 3004, 1012, 15, 60, "ExampleText",ExpressionUUID->"8426917f-e9a1-9b4a-b254-015f536580c5",
  CellID->135010306],
-Cell[119927, 2915, 1301, 20, 58, "ExampleText",ExpressionUUID->"353ad895-6faf-2643-85a6-a8331bb20202",
+Cell[124104, 3021, 1301, 20, 60, "ExampleText",ExpressionUUID->"353ad895-6faf-2643-85a6-a8331bb20202",
  CellID->359104851]
 }, Open  ]]
 }, Open  ]],
-Cell[121255, 2939, 251, 5, 35, "ExampleSection",ExpressionUUID->"6f8a9891-1da3-4c2a-8d54-2a23b4e48ef2",
+Cell[125432, 3045, 251, 5, 35, "ExampleSection",ExpressionUUID->"6f8a9891-1da3-4c2a-8d54-2a23b4e48ef2",
  CellID->221762665],
-Cell[121509, 2946, 256, 5, 23, "ExampleSection",ExpressionUUID->"0ae43145-54ab-47b0-853b-c06f35087266",
+Cell[125686, 3052, 256, 5, 21, "ExampleSection",ExpressionUUID->"0ae43145-54ab-47b0-853b-c06f35087266",
  CellID->194169788],
-Cell[121768, 2953, 249, 5, 23, "ExampleSection",ExpressionUUID->"df11dd4a-6677-4027-850d-81be8390d86e",
+Cell[125945, 3059, 249, 5, 21, "ExampleSection",ExpressionUUID->"df11dd4a-6677-4027-850d-81be8390d86e",
  CellID->205778757]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[122054, 2963, 110, 1, 72, "MetadataSection",ExpressionUUID->"f42a207b-c1a5-4b72-bffd-171b7c78e43a",
+Cell[126231, 3069, 110, 1, 78, "MetadataSection",ExpressionUUID->"f42a207b-c1a5-4b72-bffd-171b7c78e43a",
  CellID->892947207],
-Cell[122167, 2966, 474, 12, 26, "History",ExpressionUUID->"043659d4-bd7a-41e3-8d6d-5096845cfc0e",
+Cell[126344, 3072, 474, 12, 28, "History",ExpressionUUID->"043659d4-bd7a-41e3-8d6d-5096845cfc0e",
  CellID->5319953],
 Cell[CellGroupData[{
-Cell[122666, 2982, 483, 13, 21, "CategorizationSection",ExpressionUUID->"f42be207-fac4-45ff-9b65-f94b8dd6fd9f",
+Cell[126843, 3088, 483, 13, 22, "CategorizationSection",ExpressionUUID->"f42be207-fac4-45ff-9b65-f94b8dd6fd9f",
  CellID->99447318],
-Cell[123152, 2997, 134, 2, 34, "Categorization",ExpressionUUID->"c778a203-35fe-4567-93f1-8c6b1bcd183f",
+Cell[127329, 3103, 134, 2, 37, "Categorization",ExpressionUUID->"c778a203-35fe-4567-93f1-8c6b1bcd183f",
  CellID->280483579],
-Cell[123289, 3001, 159, 2, 34, "Categorization",ExpressionUUID->"2a039ea4-f2c3-46b2-9d95-f31ba7977b39",
+Cell[127466, 3107, 159, 2, 37, "Categorization",ExpressionUUID->"2a039ea4-f2c3-46b2-9d95-f31ba7977b39",
  CellID->513088406],
-Cell[123451, 3005, 156, 2, 34, "Categorization",ExpressionUUID->"1a707789-5b23-4dca-b002-5ed992e7c839",
+Cell[127628, 3111, 156, 2, 37, "Categorization",ExpressionUUID->"1a707789-5b23-4dca-b002-5ed992e7c839",
  CellID->424615657],
-Cell[123610, 3009, 268, 5, 34, "Categorization",ExpressionUUID->"a1b1c2fc-53fa-431d-a0fe-f18cd23daaba",
+Cell[127787, 3115, 268, 5, 37, "Categorization",ExpressionUUID->"a1b1c2fc-53fa-431d-a0fe-f18cd23daaba",
  CellID->324277285]
 }, Closed]],
 Cell[CellGroupData[{
-Cell[123915, 3019, 110, 1, 21, "KeywordsSection",ExpressionUUID->"37f42972-c976-465c-86ba-9ab841d611b5",
+Cell[128092, 3125, 110, 1, 23, "KeywordsSection",ExpressionUUID->"37f42972-c976-465c-86ba-9ab841d611b5",
  CellID->157024413],
-Cell[124028, 3022, 99, 1, 20, "Keywords",ExpressionUUID->"b50ec6a9-d57d-4e72-b445-88cf73b961f7",
+Cell[128205, 3128, 99, 1, 21, "Keywords",ExpressionUUID->"b50ec6a9-d57d-4e72-b445-88cf73b961f7",
  CellID->369608981]
 }, Closed]],
 Cell[CellGroupData[{
-Cell[124164, 3028, 118, 1, 21, "TemplatesSection",ExpressionUUID->"7ad12944-0259-4015-87e6-e35907a9425a",
+Cell[128341, 3134, 118, 1, 23, "TemplatesSection",ExpressionUUID->"7ad12944-0259-4015-87e6-e35907a9425a",
  CellID->30111239],
-Cell[124285, 3031, 148, 2, 27, "Template",ExpressionUUID->"73cd4a0a-b323-440e-aafa-198f5e56a0cd",
+Cell[128462, 3137, 148, 2, 29, "Template",ExpressionUUID->"73cd4a0a-b323-440e-aafa-198f5e56a0cd",
  CellID->212216560],
-Cell[124436, 3035, 137, 2, 27, "Template",ExpressionUUID->"954f59e2-12e7-4b48-89ad-b7e99ee0344d",
+Cell[128613, 3141, 137, 2, 29, "Template",ExpressionUUID->"954f59e2-12e7-4b48-89ad-b7e99ee0344d",
  CellID->393173875],
-Cell[124576, 3039, 135, 2, 27, "Template",ExpressionUUID->"5a4f48b7-d6e5-4ac6-a99d-27c2b08ba3a6",
+Cell[128753, 3145, 135, 2, 29, "Template",ExpressionUUID->"5a4f48b7-d6e5-4ac6-a99d-27c2b08ba3a6",
  CellID->140031180],
-Cell[124714, 3043, 136, 2, 27, "Template",ExpressionUUID->"ea191618-1ca8-4fd2-b80f-eeec0e7640b0",
+Cell[128891, 3149, 136, 2, 29, "Template",ExpressionUUID->"ea191618-1ca8-4fd2-b80f-eeec0e7640b0",
  CellID->94782372]
 }, Closed]]
 }, Open  ]]

--- a/Paclet/Documentation/English/ReferencePages/Symbols/NonReciprocalAbelianBlochHamiltonianExpression.nb
+++ b/Paclet/Documentation/English/ReferencePages/Symbols/NonReciprocalAbelianBlochHamiltonianExpression.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[    103841,       2636]
-NotebookOptionsPosition[     91801,       2377]
-NotebookOutlinePosition[     92579,       2402]
-CellTagsIndexPosition[     92499,       2397]
+NotebookDataLength[    108105,       2744]
+NotebookOptionsPosition[     95707,       2479]
+NotebookOutlinePosition[     96491,       2504]
+CellTagsIndexPosition[     96411,       2499]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -214,6 +214,108 @@ edge or a number if ",
  CellChangeTimes->{{3.934472130593386*^9, 3.9344721565686*^9}, {
   3.937420928044874*^9, 3.937420947325117*^9}},
  CellID->129485177,ExpressionUUID->"e1151d60-8292-1342-b3de-89475e41ebd5"],
+
+Cell[TextData[{
+ "For multi-orbital models with ",
+ Cell[BoxData[
+  StyleBox["norb", "TI"]], "InlineFormula",ExpressionUUID->
+  "aab592ea-6fa4-6949-8121-6558f6e7797e"],
+ "\[NotEqual]",
+ StyleBox["1", "InlineCode"],
+ ", the specification of the hopping matrix for the hopping amplitudes  ",
+ Cell[BoxData[
+  StyleBox["hoppingsOpposite", "TI"]], "InlineFormula",ExpressionUUID->
+  "26d0bd6a-8b77-f640-b9d9-d0bbf802a138"],
+ " need to follow the same assignment conventions as the hopping amplitudes \
+",
+ Cell[BoxData[
+  StyleBox["hoppingsCanonical", "TI"]], "InlineFormula",ExpressionUUID->
+  "85cd8748-f9fc-124e-a98a-56009aff9946"],
+ ". In order to illustrate the used convention it is instructive to consider \
+a general two-orbital ",
+ StyleBox["{p,q}", "InlineCode"],
+ "-lattice model with nearest-neighbor interactions on an arbitrary unit cell \
+with two sites. Consider the two sites ",
+ StyleBox["i", "InlineCode"],
+ " and ",
+ StyleBox["j", "InlineCode"],
+ " in a unit cell, each equipped with two orbitals ",
+ StyleBox["a", "InlineCode"],
+ " and ",
+ StyleBox["b", "InlineCode"],
+ ". Further, let a hopping in the canonical direction be defined as ",
+ StyleBox["i", "InlineCode"],
+ " \[Rule] ",
+ StyleBox["j,", "InlineCode"],
+ " and ",
+ StyleBox["j", "InlineCode"],
+ " \[Rule] ",
+ StyleBox["i", "InlineCode"],
+ " in the opposite direction. The following hopping matrices need to be \
+specified, where each matrix entry specifies the corresponding hopping \
+amplitudes between corresponding pairs of orbitals:"
+}], "Notes",
+ CellChangeTimes->{{3.959416241755583*^9, 3.959416242459528*^9}, {
+   3.9594167264317684`*^9, 3.959416768108032*^9}, {3.959417246453047*^9, 
+   3.9594172834939194`*^9}, 3.9594174076191235`*^9, {3.9594180058355064`*^9, 
+   3.9594180491644745`*^9}, {3.9594184160936623`*^9, 3.959418652769972*^9}, {
+   3.9594186847437496`*^9, 3.9594187085016575`*^9}, {3.9594187469976215`*^9, 
+   3.959418815211241*^9}, {3.959419067188925*^9, 3.959419090362995*^9}, {
+   3.9594205426341953`*^9, 3.9594205767974167`*^9}},
+ CellID->311370265,ExpressionUUID->"fa3260dd-a9d7-f943-a61c-61a0b29eaba0"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{
+   RowBox[{"hoppingsCanonical", "=", 
+    RowBox[{
+     RowBox[{"(", GridBox[{
+        {
+         RowBox[{
+          SubscriptBox["a", "i"], "\[Rule]", 
+          SubscriptBox["a", "j"]}], 
+         RowBox[{
+          SubscriptBox["a", "i"], "\[Rule]", 
+          SubscriptBox["b", "j"]}]},
+        {
+         RowBox[{
+          SubscriptBox["b", "i"], "\[Rule]", 
+          SubscriptBox["b", "j"]}], 
+         RowBox[{
+          SubscriptBox["b", "i"], "\[Rule]", 
+          SubscriptBox["b", "j"]}]}
+       }], ")"}], "&"}]}], ";"}], " "}]], "Notes",
+ CellChangeTimes->{{3.9594190921442356`*^9, 3.9594191869209785`*^9}, {
+   3.9594199305607395`*^9, 3.959419942131056*^9}, 3.9594199844307747`*^9, {
+   3.959420111086876*^9, 3.9594201114812164`*^9}, 3.959420152732893*^9},
+ CellID->207376718,ExpressionUUID->"1671ed16-39a8-f84a-a5e7-5d09eddfa739"],
+
+Cell[TextData[Cell[BoxData[
+ RowBox[{
+  RowBox[{"hoppingsOpposite", "=", 
+   RowBox[{
+    RowBox[{"(", GridBox[{
+       {
+        RowBox[{
+         SubscriptBox["a", "i"], "\[LeftArrow]", 
+         SubscriptBox["a", "j"]}], 
+        RowBox[{
+         SubscriptBox["a", "i"], "\[LeftArrow]", 
+         SubscriptBox["b", "j"]}]},
+       {
+        RowBox[{
+         SubscriptBox["b", "i"], "\[LeftArrow]", 
+         SubscriptBox["b", "j"]}], 
+        RowBox[{
+         SubscriptBox["b", "i"], "\[LeftArrow]", 
+         SubscriptBox["b", "j"]}]}
+      }], ")"}], "&"}]}], ";"}]],
+ CellChangeTimes->{{3.9594190921442356`*^9, 3.9594191869209785`*^9}, {
+  3.9594199305607395`*^9, 
+  3.959419942131056*^9}},ExpressionUUID->"8ff0a281-19c1-f348-9852-\
+6195910c8754"]], "Notes",
+ CellChangeTimes->{{3.959420522251034*^9, 3.9594205393492985`*^9}},
+ CellID->396819643,ExpressionUUID->"0e8e3364-61e7-6942-8a3f-0ff75a294039"],
 
 Cell[TextData[{
  Cell[BoxData[
@@ -423,10 +525,10 @@ AbelianBlochHamiltonianExpression"]], "InlineSeeAlsoFunction",
     "dc85d5f4-7a98-45de-8522-589a7ed082b5"], 
    DynamicModuleBox[{$CellContext`nbobj$$ = NotebookObject[
     "d13007c1-f945-4caf-9c39-96e1de350f63", 
-     "731de9ba-c41f-ee40-9589-aaf19c22e279"], $CellContext`cellobj$$ = 
+     "6d1e3cfd-5829-c94a-986a-eb01c6785923"], $CellContext`cellobj$$ = 
     CellObject[
     "e4b2c6e8-2a34-43c4-ab33-420ee3451b24", 
-     "21a4907a-f8a5-1f44-8ad5-c6f7f54caff6"]}, 
+     "52796c7d-dc94-3740-97d4-d100b6caf4f5"]}, 
     TemplateBox[{
       GraphicsBox[{{
          Thickness[0.06], 
@@ -2376,9 +2478,9 @@ Cell[BoxData[""], "Template",
 }, Open  ]]
 },
 WindowSize->{1269, 647},
-WindowMargins->{{0, Automatic}, {Automatic, 0}},
+WindowMargins->{{22.5, Automatic}, {Automatic, 21.5}},
 TaggingRules-><|"Paclet" -> "PatrickMLenggenhager/HyperBloch"|>,
-FrontEndVersion->"14.0 for Microsoft Windows (64-bit) (December 12, 2023)",
+FrontEndVersion->"14.2 for Microsoft Windows (64-bit) (December 26, 2024)",
 StyleDefinitions->FrontEnd`FileName[{"Wolfram"}, "FunctionPageStylesExt.nb", 
   CharacterEncoding -> "UTF-8"],
 ExpressionUUID->"d13007c1-f945-4caf-9c39-96e1de350f63"
@@ -2389,252 +2491,258 @@ ExpressionUUID->"d13007c1-f945-4caf-9c39-96e1de350f63"
 (*CellTagsOutline
 CellTagsIndex->{
  "ExtendedExamples"->{
-  Cell[39782, 1068, 487, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"f66a8592-336f-436f-a669-374caa490be8",
+  Cell[43688, 1170, 487, 13, 56, "ExtendedExamplesSection",ExpressionUUID->"f66a8592-336f-436f-a669-374caa490be8",
    CellTags->"ExtendedExamples",
    CellID->326378688]}
  }
 *)
 (*CellTagsIndex
 CellTagsIndex->{
- {"ExtendedExamples", 92304, 2390}
+ {"ExtendedExamples", 96216, 2492}
  }
 *)
 (*NotebookFileOutline
 Notebook[{
 Cell[CellGroupData[{
-Cell[580, 22, 208, 2, 74, "ObjectName",ExpressionUUID->"e13727bc-dacc-4fb6-b263-63e32ad6c083",
+Cell[580, 22, 208, 2, 72, "ObjectName",ExpressionUUID->"e13727bc-dacc-4fb6-b263-63e32ad6c083",
  CellID->487529978],
-Cell[791, 26, 2828, 67, 155, "Usage",ExpressionUUID->"9d01a708-6a9a-4a0b-84f1-164256a41ecf",
+Cell[791, 26, 2828, 67, 148, "Usage",ExpressionUUID->"9d01a708-6a9a-4a0b-84f1-164256a41ecf",
  CellID->19881515],
-Cell[3622, 95, 1212, 30, 48, "Notes",ExpressionUUID->"3e5204e8-3be9-4da4-9501-5649808fc72a",
+Cell[3622, 95, 1212, 30, 46, "Notes",ExpressionUUID->"3e5204e8-3be9-4da4-9501-5649808fc72a",
  CellID->642025679],
-Cell[4837, 127, 1090, 28, 48, "Notes",ExpressionUUID->"b25c64ad-3301-4f8e-a559-da0473698204",
+Cell[4837, 127, 1090, 28, 46, "Notes",ExpressionUUID->"b25c64ad-3301-4f8e-a559-da0473698204",
  CellID->140612745],
-Cell[5930, 157, 1235, 29, 69, "Notes",ExpressionUUID->"7b449629-e8dc-dd43-ba20-5ffdb044811a",
+Cell[5930, 157, 1235, 29, 67, "Notes",ExpressionUUID->"7b449629-e8dc-dd43-ba20-5ffdb044811a",
  CellID->258865958],
-Cell[7168, 188, 1064, 27, 69, "Notes",ExpressionUUID->"e1151d60-8292-1342-b3de-89475e41ebd5",
+Cell[7168, 188, 1064, 27, 67, "Notes",ExpressionUUID->"e1151d60-8292-1342-b3de-89475e41ebd5",
  CellID->129485177],
-Cell[8235, 217, 805, 18, 49, "Notes",ExpressionUUID->"740bbe1c-6f24-48dd-8911-626dc1580f8d",
+Cell[8235, 217, 2105, 47, 156, "Notes",ExpressionUUID->"fa3260dd-a9d7-f943-a61c-61a0b29eaba0",
+ CellID->311370265],
+Cell[10343, 266, 882, 24, 41, "Notes",ExpressionUUID->"1671ed16-39a8-f84a-a5e7-5d09eddfa739",
+ CellID->207376718],
+Cell[11228, 292, 910, 25, 41, "Notes",ExpressionUUID->"0e8e3364-61e7-6942-8a3f-0ff75a294039",
+ CellID->396819643],
+Cell[12141, 319, 805, 18, 46, "Notes",ExpressionUUID->"740bbe1c-6f24-48dd-8911-626dc1580f8d",
  CellID->679798389],
-Cell[9043, 237, 221, 3, 27, "Notes",ExpressionUUID->"c22ece98-50cc-4c63-ac53-96ee03b7e01d",
+Cell[12949, 339, 221, 3, 26, "Notes",ExpressionUUID->"c22ece98-50cc-4c63-ac53-96ee03b7e01d",
  CellID->122405462],
-Cell[9267, 242, 1770, 41, 103, "3ColumnTableMod",ExpressionUUID->"f591d055-2723-4966-8f6e-7ff27d82b11a",
+Cell[13173, 344, 1770, 41, 87, "3ColumnTableMod",ExpressionUUID->"f591d055-2723-4966-8f6e-7ff27d82b11a",
  CellID->65923218]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[11074, 288, 435, 12, 40, "TechNotesSection",ExpressionUUID->"f47e3415-f834-4914-a486-b823af301d1d",
+Cell[14980, 390, 435, 12, 39, "TechNotesSection",ExpressionUUID->"f47e3415-f834-4914-a486-b823af301d1d",
  CellID->909304175],
-Cell[11512, 302, 265, 6, 19, "Tutorials",ExpressionUUID->"7fc3f6ab-32a9-4701-a8e3-f6735c45ed1e",
+Cell[15418, 404, 265, 6, 17, "Tutorials",ExpressionUUID->"7fc3f6ab-32a9-4701-a8e3-f6735c45ed1e",
  CellID->151400]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[11814, 313, 472, 13, 39, "RelatedLinksSection",ExpressionUUID->"02244713-76a0-4f33-b1e3-b8a5d51ca845",
+Cell[15720, 415, 472, 13, 38, "RelatedLinksSection",ExpressionUUID->"02244713-76a0-4f33-b1e3-b8a5d51ca845",
  CellID->668778174],
-Cell[12289, 328, 102, 1, 19, "RelatedLinks",ExpressionUUID->"ba862e54-c50d-4e86-b0e8-d37e37a51cd0",
+Cell[16195, 430, 102, 1, 17, "RelatedLinks",ExpressionUUID->"ba862e54-c50d-4e86-b0e8-d37e37a51cd0",
  CellID->31080045]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[12428, 334, 458, 13, 39, "SeeAlsoSection",ExpressionUUID->"4ba55984-5139-4fcd-9e53-1cad8de1caa8",
+Cell[16334, 436, 458, 13, 38, "SeeAlsoSection",ExpressionUUID->"4ba55984-5139-4fcd-9e53-1cad8de1caa8",
  CellID->171383757],
-Cell[12889, 349, 4471, 108, 61, "SeeAlso",ExpressionUUID->"4eb40240-d0ca-4d06-b0ca-4394e89ed113",
+Cell[16795, 451, 4471, 108, 50, "SeeAlso",ExpressionUUID->"4eb40240-d0ca-4d06-b0ca-4394e89ed113",
  CellID->705308221]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[17397, 462, 183, 2, 39, "MoreAboutSection",ExpressionUUID->"d2d8457c-dfa6-4bed-a65a-ca11a7fbcca3",
+Cell[21303, 564, 183, 2, 37, "MoreAboutSection",ExpressionUUID->"d2d8457c-dfa6-4bed-a65a-ca11a7fbcca3",
  CellID->695784319],
-Cell[17583, 466, 281, 6, 19, "MoreAbout",ExpressionUUID->"67e2307f-8548-4d7c-a334-5ac9c3a54950",
+Cell[21489, 568, 281, 6, 17, "MoreAbout",ExpressionUUID->"67e2307f-8548-4d7c-a334-5ac9c3a54950",
  CellID->542581366]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[17901, 477, 529, 14, 69, "ExamplesInitializationSection",ExpressionUUID->"9514d01e-d4b4-4058-86bd-f20fd3ab07bc",
+Cell[21807, 579, 529, 14, 68, "ExamplesInitializationSection",ExpressionUUID->"9514d01e-d4b4-4058-86bd-f20fd3ab07bc",
  CellID->99901568],
-Cell[18433, 493, 308, 5, 45, "ExampleInitialization",ExpressionUUID->"ce892e22-556e-4cda-aed6-4e3ba77f9c27",
+Cell[22339, 595, 308, 5, 45, "ExampleInitialization",ExpressionUUID->"ce892e22-556e-4cda-aed6-4e3ba77f9c27",
  CellID->75714804]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[18778, 503, 441, 12, 71, "PrimaryExamplesSection",ExpressionUUID->"cb04f553-66b7-482d-a771-988eed0afb9c",
+Cell[22684, 605, 441, 12, 69, "PrimaryExamplesSection",ExpressionUUID->"cb04f553-66b7-482d-a771-988eed0afb9c",
  CellID->11026314],
-Cell[19222, 517, 890, 15, 77, "ExampleText",ExpressionUUID->"fe456159-779a-40e4-b90c-50fbbbdafc5f",
+Cell[23128, 619, 890, 15, 71, "ExampleText",ExpressionUUID->"fe456159-779a-40e4-b90c-50fbbbdafc5f",
  CellID->82755364],
 Cell[CellGroupData[{
-Cell[20137, 536, 898, 17, 43, "Input",ExpressionUUID->"ac881db1-505d-44dd-8c11-29c4ababfcca",
+Cell[24043, 638, 898, 17, 42, "Input",ExpressionUUID->"ac881db1-505d-44dd-8c11-29c4ababfcca",
  CellID->2282893],
-Cell[21038, 555, 1293, 34, 28, "Output",ExpressionUUID->"f6de1f59-7e7d-430b-aa27-7d239cdd518b",
+Cell[24944, 657, 1293, 34, 26, "Output",ExpressionUUID->"f6de1f59-7e7d-430b-aa27-7d239cdd518b",
  CellID->596936726]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[22368, 594, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"0d27364f-6a4a-41cd-8346-79a61252b6a1",
+Cell[26274, 696, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"0d27364f-6a4a-41cd-8346-79a61252b6a1",
  CellID->359821871],
-Cell[22613, 601, 286, 4, 24, "ExampleText",ExpressionUUID->"fac98d31-9663-47af-a4e5-08d1ebcb9f63",
+Cell[26519, 703, 286, 4, 23, "ExampleText",ExpressionUUID->"fac98d31-9663-47af-a4e5-08d1ebcb9f63",
  CellID->36408547],
 Cell[CellGroupData[{
-Cell[22924, 609, 1060, 20, 43, "Input",ExpressionUUID->"95fcf837-6c1b-4329-8d21-6642a74e79a8",
+Cell[26830, 711, 1060, 20, 42, "Input",ExpressionUUID->"95fcf837-6c1b-4329-8d21-6642a74e79a8",
  CellID->633400500],
-Cell[23987, 631, 1555, 44, 49, "Output",ExpressionUUID->"21e14cea-9a0e-45cf-9db1-bbe834c721d1",
+Cell[27893, 733, 1555, 44, 47, "Output",ExpressionUUID->"21e14cea-9a0e-45cf-9db1-bbe834c721d1",
  CellID->384403571]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[25591, 681, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"6f664ba6-6c53-42b9-896f-a2581d917c9a",
+Cell[29497, 783, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"6f664ba6-6c53-42b9-896f-a2581d917c9a",
  CellID->677196106],
-Cell[25836, 688, 1346, 28, 79, "ExampleText",ExpressionUUID->"e3b8ece6-3cc9-4858-8f68-4b8698f8e5fe",
+Cell[29742, 790, 1346, 28, 71, "ExampleText",ExpressionUUID->"e3b8ece6-3cc9-4858-8f68-4b8698f8e5fe",
  CellID->680708440],
 Cell[CellGroupData[{
-Cell[27207, 720, 5159, 144, 310, "Input",ExpressionUUID->"a3ba0bbe-867d-49f6-930b-2f9ce301407e",
+Cell[31113, 822, 5159, 144, 309, "Input",ExpressionUUID->"a3ba0bbe-867d-49f6-930b-2f9ce301407e",
  CellID->262417576],
-Cell[32369, 866, 1489, 41, 28, "Output",ExpressionUUID->"efc29266-40ba-49be-a1cf-b84decb63afa",
+Cell[36275, 968, 1489, 41, 26, "Output",ExpressionUUID->"efc29266-40ba-49be-a1cf-b84decb63afa",
  CellID->1840780417]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[33907, 913, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"0acee9e9-b06e-44f6-8e0d-3416aee46a15",
+Cell[37813, 1015, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"0acee9e9-b06e-44f6-8e0d-3416aee46a15",
  CellID->228953716],
-Cell[34152, 920, 1209, 24, 60, "ExampleText",ExpressionUUID->"2b77b004-ee91-4f85-a423-e0925f110a86",
+Cell[38058, 1022, 1209, 24, 55, "ExampleText",ExpressionUUID->"2b77b004-ee91-4f85-a423-e0925f110a86",
  CellID->16699796],
 Cell[CellGroupData[{
-Cell[35386, 948, 1719, 42, 159, "Input",ExpressionUUID->"af5ddb53-5b80-49af-96c3-756fe4ccaec9",
+Cell[39292, 1050, 1719, 42, 158, "Input",ExpressionUUID->"af5ddb53-5b80-49af-96c3-756fe4ccaec9",
  CellID->78835713],
-Cell[37108, 992, 2613, 69, 49, "Output",ExpressionUUID->"2165acae-2d7c-f94d-a0ae-f1bbb8f98a70",
+Cell[41014, 1094, 2613, 69, 47, "Output",ExpressionUUID->"2165acae-2d7c-f94d-a0ae-f1bbb8f98a70",
  CellID->140578249]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[39782, 1068, 487, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"f66a8592-336f-436f-a669-374caa490be8",
+Cell[43688, 1170, 487, 13, 56, "ExtendedExamplesSection",ExpressionUUID->"f66a8592-336f-436f-a669-374caa490be8",
  CellTags->"ExtendedExamples",
  CellID->326378688],
 Cell[CellGroupData[{
-Cell[40294, 1085, 241, 5, 35, "ExampleSection",ExpressionUUID->"da147fcf-b8f0-4218-9c13-c664b65b2c3a",
+Cell[44200, 1187, 241, 5, 32, "ExampleSection",ExpressionUUID->"da147fcf-b8f0-4218-9c13-c664b65b2c3a",
  CellID->452520281],
 Cell[CellGroupData[{
-Cell[40560, 1094, 182, 2, 24, "ExampleSubsection",ExpressionUUID->"d4a00df3-6032-46aa-8c43-08d318b86920",
+Cell[44466, 1196, 182, 2, 23, "ExampleSubsection",ExpressionUUID->"d4a00df3-6032-46aa-8c43-08d318b86920",
  CellID->198501545],
-Cell[40745, 1098, 327, 6, 41, "ExampleText",ExpressionUUID->"4e1748c6-5972-4e9d-a5d7-a6bba5e0c15b",
+Cell[44651, 1200, 327, 6, 39, "ExampleText",ExpressionUUID->"4e1748c6-5972-4e9d-a5d7-a6bba5e0c15b",
  CellID->293180495],
-Cell[41075, 1106, 628, 14, 43, "Input",ExpressionUUID->"b1a3429b-0a07-4f33-ae72-2428e5482c38",
+Cell[44981, 1208, 628, 14, 42, "Input",ExpressionUUID->"b1a3429b-0a07-4f33-ae72-2428e5482c38",
  CellID->407621152],
 Cell[CellGroupData[{
-Cell[41728, 1124, 454, 10, 25, "Input",ExpressionUUID->"e839607d-07d1-4235-ad2f-67cd3e6762a4",
+Cell[45634, 1226, 454, 10, 25, "Input",ExpressionUUID->"e839607d-07d1-4235-ad2f-67cd3e6762a4",
  CellID->244028921],
-Cell[42185, 1136, 450, 10, 24, "Output",ExpressionUUID->"043e71d8-dd3f-42f2-8453-5be428587ba1",
+Cell[46091, 1238, 450, 10, 24, "Output",ExpressionUUID->"043e71d8-dd3f-42f2-8453-5be428587ba1",
  CellID->1295901354]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[42672, 1151, 632, 14, 43, "Input",ExpressionUUID->"34767bf5-b825-c44d-907f-3ce5e271e699",
+Cell[46578, 1253, 632, 14, 42, "Input",ExpressionUUID->"34767bf5-b825-c44d-907f-3ce5e271e699",
  CellID->197552022],
-Cell[43307, 1167, 1989, 65, 64, "Output",ExpressionUUID->"99acf93f-1c04-8c4c-80fa-d7c02718cd11",
+Cell[47213, 1269, 1989, 65, 62, "Output",ExpressionUUID->"99acf93f-1c04-8c4c-80fa-d7c02718cd11",
  CellID->832281926]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[45333, 1237, 737, 14, 43, "Input",ExpressionUUID->"bc22d04e-4e96-e04a-b73a-128982c74e0b",
+Cell[49239, 1339, 737, 14, 42, "Input",ExpressionUUID->"bc22d04e-4e96-e04a-b73a-128982c74e0b",
  CellID->156019331],
-Cell[46073, 1253, 1910, 61, 64, "Output",ExpressionUUID->"5dad78ef-68c0-c248-abad-2a697c48a75c",
+Cell[49979, 1355, 1910, 61, 62, "Output",ExpressionUUID->"5dad78ef-68c0-c248-abad-2a697c48a75c",
  CellID->247750513]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[48020, 1319, 786, 13, 43, "Input",ExpressionUUID->"fa73fb48-6a75-8545-8bf7-3096919d7b42",
+Cell[51926, 1421, 786, 13, 42, "Input",ExpressionUUID->"fa73fb48-6a75-8545-8bf7-3096919d7b42",
  CellID->657327319],
-Cell[48809, 1334, 4814, 129, 108, "Output",ExpressionUUID->"f5986d47-a0bf-b343-b95d-5eb4e15b8adb",
+Cell[52715, 1436, 4814, 129, 106, "Output",ExpressionUUID->"f5986d47-a0bf-b343-b95d-5eb4e15b8adb",
  CellID->110703830]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
-Cell[53662, 1468, 264, 5, 35, "ExampleSection",ExpressionUUID->"b38c68de-babb-4527-9b5b-919b90448d9a",
+Cell[57568, 1570, 264, 5, 32, "ExampleSection",ExpressionUUID->"b38c68de-babb-4527-9b5b-919b90448d9a",
  CellID->112538656],
 Cell[CellGroupData[{
-Cell[53951, 1477, 243, 5, 23, "ExampleSection",ExpressionUUID->"d9560930-ab18-4795-8acc-798ab4243332",
+Cell[57857, 1579, 243, 5, 20, "ExampleSection",ExpressionUUID->"d9560930-ab18-4795-8acc-798ab4243332",
  CellID->476698288],
 Cell[CellGroupData[{
-Cell[54219, 1486, 317, 6, 26, "ExampleSubsection",ExpressionUUID->"7cec6767-bb80-4457-8716-b1658dd1e46a",
+Cell[58125, 1588, 317, 6, 23, "ExampleSubsection",ExpressionUUID->"7cec6767-bb80-4457-8716-b1658dd1e46a",
  CellID->200887691],
-Cell[54539, 1494, 276, 5, 24, "ExampleText",ExpressionUUID->"4f95c364-93f1-4778-af4e-1ca1ee6be804",
+Cell[58445, 1596, 276, 5, 23, "ExampleText",ExpressionUUID->"4f95c364-93f1-4778-af4e-1ca1ee6be804",
  CellID->654805157],
 Cell[CellGroupData[{
-Cell[54840, 1503, 1986, 48, 166, "Input",ExpressionUUID->"c74efb92-0269-794b-af7f-4b6829c7bb10",
+Cell[58746, 1605, 1986, 48, 165, "Input",ExpressionUUID->"c74efb92-0269-794b-af7f-4b6829c7bb10",
  CellID->671148953],
-Cell[56829, 1553, 4813, 129, 108, "Output",ExpressionUUID->"de8807a4-9d2a-174c-aa27-d4b4aaeae312",
+Cell[60735, 1655, 4813, 129, 106, "Output",ExpressionUUID->"de8807a4-9d2a-174c-aa27-d4b4aaeae312",
  CellID->1280785804]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[61691, 1688, 718, 13, 28, "ExampleSubsection",ExpressionUUID->"70c5f4f4-489a-465c-a365-a3a6bb3afe2d",
+Cell[65597, 1790, 718, 13, 23, "ExampleSubsection",ExpressionUUID->"70c5f4f4-489a-465c-a365-a3a6bb3afe2d",
  CellID->1036996805],
-Cell[62412, 1703, 411, 10, 26, "ExampleText",ExpressionUUID->"041cec4a-5956-4da6-8304-a081527c2538",
+Cell[66318, 1805, 411, 10, 23, "ExampleText",ExpressionUUID->"041cec4a-5956-4da6-8304-a081527c2538",
  CellID->1975506230],
 Cell[CellGroupData[{
-Cell[62848, 1717, 865, 19, 61, "Input",ExpressionUUID->"f384a361-0a20-4bcc-ac15-506b4cbc0d3b",
+Cell[66754, 1819, 865, 19, 60, "Input",ExpressionUUID->"f384a361-0a20-4bcc-ac15-506b4cbc0d3b",
  CellID->88541343],
-Cell[63716, 1738, 10683, 224, 53, "Output",ExpressionUUID->"3e6cc0ba-a89f-431d-8426-c1b7e5ad5225",
+Cell[67622, 1840, 10683, 224, 50, "Output",ExpressionUUID->"3e6cc0ba-a89f-431d-8426-c1b7e5ad5225",
  CellID->254211235]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
-Cell[74438, 1967, 248, 5, 35, "ExampleSection",ExpressionUUID->"0d54ec61-ab7c-4802-a22b-16908247134f",
+Cell[78344, 2069, 248, 5, 32, "ExampleSection",ExpressionUUID->"0d54ec61-ab7c-4802-a22b-16908247134f",
  CellID->466091341],
 Cell[CellGroupData[{
-Cell[74711, 1976, 258, 5, 23, "ExampleSection",ExpressionUUID->"ae535a9b-e8d7-4579-92e7-f72773096d65",
+Cell[78617, 2078, 258, 5, 20, "ExampleSection",ExpressionUUID->"ae535a9b-e8d7-4579-92e7-f72773096d65",
  CellID->113613961],
 Cell[CellGroupData[{
-Cell[74994, 1985, 767, 14, 28, "ExampleSubsection",ExpressionUUID->"7e375bee-9264-784e-8fc9-b01785875e8b",
+Cell[78900, 2087, 767, 14, 23, "ExampleSubsection",ExpressionUUID->"7e375bee-9264-784e-8fc9-b01785875e8b",
  CellID->296669070],
-Cell[75764, 2001, 1472, 25, 60, "ExampleText",ExpressionUUID->"d0fa4c32-017f-6941-9e2b-bed568d07987",
+Cell[79670, 2103, 1472, 25, 55, "ExampleText",ExpressionUUID->"d0fa4c32-017f-6941-9e2b-bed568d07987",
  CellID->105689035],
-Cell[77239, 2028, 1559, 26, 41, "ExampleText",ExpressionUUID->"de31d0fe-301c-a442-b6c2-0da829655420",
+Cell[81145, 2130, 1559, 26, 39, "ExampleText",ExpressionUUID->"de31d0fe-301c-a442-b6c2-0da829655420",
  CellID->709734105],
-Cell[78801, 2056, 1444, 28, 77, "ExampleText",ExpressionUUID->"efc5cb6f-fc63-7e4a-a77b-e01c3c1ceac3",
+Cell[82707, 2158, 1444, 28, 71, "ExampleText",ExpressionUUID->"efc5cb6f-fc63-7e4a-a77b-e01c3c1ceac3",
  CellID->105347582],
 Cell[CellGroupData[{
-Cell[80270, 2088, 2336, 52, 159, "Input",ExpressionUUID->"afc51794-de33-a843-84c0-d8eb813a2698",
+Cell[84176, 2190, 2336, 52, 158, "Input",ExpressionUUID->"afc51794-de33-a843-84c0-d8eb813a2698",
  CellID->448289478],
-Cell[82609, 2142, 3207, 80, 49, "Output",ExpressionUUID->"6f65396e-fec0-b440-ac40-9c94c63f6915",
+Cell[86515, 2244, 3207, 80, 47, "Output",ExpressionUUID->"6f65396e-fec0-b440-ac40-9c94c63f6915",
  CellID->1351737]
 }, Open  ]],
-Cell[85831, 2225, 1012, 15, 58, "ExampleText",ExpressionUUID->"d0b215a8-271e-7748-8dce-b5f2ca7ba53d",
+Cell[89737, 2327, 1012, 15, 55, "ExampleText",ExpressionUUID->"d0b215a8-271e-7748-8dce-b5f2ca7ba53d",
  CellID->135010306],
-Cell[86846, 2242, 1301, 20, 58, "ExampleText",ExpressionUUID->"5e0470fd-1dee-c445-84c1-352ca10dd65d",
+Cell[90752, 2344, 1301, 20, 55, "ExampleText",ExpressionUUID->"5e0470fd-1dee-c445-84c1-352ca10dd65d",
  CellID->359104851]
 }, Open  ]]
 }, Open  ]],
-Cell[88174, 2266, 251, 5, 35, "ExampleSection",ExpressionUUID->"0eceeb89-7d50-4592-9afe-7c312252d0fb",
+Cell[92080, 2368, 251, 5, 32, "ExampleSection",ExpressionUUID->"0eceeb89-7d50-4592-9afe-7c312252d0fb",
  CellID->594336563],
-Cell[88428, 2273, 256, 5, 23, "ExampleSection",ExpressionUUID->"3232c9e5-853c-43cf-a0c3-cece249b6374",
+Cell[92334, 2375, 256, 5, 20, "ExampleSection",ExpressionUUID->"3232c9e5-853c-43cf-a0c3-cece249b6374",
  CellID->763924802],
-Cell[88687, 2280, 248, 5, 23, "ExampleSection",ExpressionUUID->"335741ac-c3bf-4f98-b769-2a015f5bbb0e",
+Cell[92593, 2382, 248, 5, 20, "ExampleSection",ExpressionUUID->"335741ac-c3bf-4f98-b769-2a015f5bbb0e",
  CellID->76990128]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[88972, 2290, 109, 1, 72, "MetadataSection",ExpressionUUID->"04cac98b-4434-4558-bb5c-a50bffbaf3c6",
+Cell[92878, 2392, 109, 1, 71, "MetadataSection",ExpressionUUID->"04cac98b-4434-4558-bb5c-a50bffbaf3c6",
  CellID->42901253],
-Cell[89084, 2293, 473, 12, 26, "History",ExpressionUUID->"a9449086-5e97-4202-a957-8ef347936728",
+Cell[92990, 2395, 473, 12, 26, "History",ExpressionUUID->"a9449086-5e97-4202-a957-8ef347936728",
  CellID->969934],
 Cell[CellGroupData[{
-Cell[89582, 2309, 484, 13, 21, "CategorizationSection",ExpressionUUID->"df9aef4c-2850-49c2-a631-981bc53613de",
+Cell[93488, 2411, 484, 13, 21, "CategorizationSection",ExpressionUUID->"df9aef4c-2850-49c2-a631-981bc53613de",
  CellID->155892578],
-Cell[90069, 2324, 134, 2, 35, "Categorization",ExpressionUUID->"37577286-8a2e-4690-95d1-258cd136aac3",
+Cell[93975, 2426, 134, 2, 35, "Categorization",ExpressionUUID->"37577286-8a2e-4690-95d1-258cd136aac3",
  CellID->379313778],
-Cell[90206, 2328, 159, 2, 35, "Categorization",ExpressionUUID->"15fdabe5-69c0-4859-8ec5-136948b0dc35",
+Cell[94112, 2430, 159, 2, 35, "Categorization",ExpressionUUID->"15fdabe5-69c0-4859-8ec5-136948b0dc35",
  CellID->123752965],
-Cell[90368, 2332, 156, 2, 35, "Categorization",ExpressionUUID->"c4965993-9dd5-4758-bf37-c7cd4d83d488",
+Cell[94274, 2434, 156, 2, 35, "Categorization",ExpressionUUID->"c4965993-9dd5-4758-bf37-c7cd4d83d488",
  CellID->207073079],
-Cell[90527, 2336, 277, 6, 35, "Categorization",ExpressionUUID->"bb49b832-e02e-40af-9542-ed5332d2229c",
+Cell[94433, 2438, 277, 6, 35, "Categorization",ExpressionUUID->"bb49b832-e02e-40af-9542-ed5332d2229c",
  CellID->485781109]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[90841, 2347, 109, 1, 31, "KeywordsSection",ExpressionUUID->"b9218ebb-8180-446d-816f-0ae498757f49",
+Cell[94747, 2449, 109, 1, 31, "KeywordsSection",ExpressionUUID->"b9218ebb-8180-446d-816f-0ae498757f49",
  CellID->55111812],
-Cell[90953, 2350, 98, 1, 21, "Keywords",ExpressionUUID->"ef98b38b-9a15-4564-a72a-1ac60a848bb4",
+Cell[94859, 2452, 98, 1, 21, "Keywords",ExpressionUUID->"ef98b38b-9a15-4564-a72a-1ac60a848bb4",
  CellID->78694749]
 }, Closed]],
 Cell[CellGroupData[{
-Cell[91088, 2356, 119, 1, 21, "TemplatesSection",ExpressionUUID->"fc1f065b-1492-425c-99fa-0fbdcd783aa2",
+Cell[94994, 2458, 119, 1, 21, "TemplatesSection",ExpressionUUID->"fc1f065b-1492-425c-99fa-0fbdcd783aa2",
  CellID->272215535],
-Cell[91210, 2359, 148, 2, 29, "Template",ExpressionUUID->"78c4c51d-f3aa-458d-8e24-a157e274b180",
+Cell[95116, 2461, 148, 2, 29, "Template",ExpressionUUID->"78c4c51d-f3aa-458d-8e24-a157e274b180",
  CellID->476199561],
-Cell[91361, 2363, 136, 2, 29, "Template",ExpressionUUID->"b58c10d5-6253-4796-b2f6-1caf21f791fc",
+Cell[95267, 2465, 136, 2, 29, "Template",ExpressionUUID->"b58c10d5-6253-4796-b2f6-1caf21f791fc",
  CellID->39443153],
-Cell[91500, 2367, 135, 2, 29, "Template",ExpressionUUID->"ebf094e1-882d-4d8c-804a-0d7e4eed420a",
+Cell[95406, 2469, 135, 2, 29, "Template",ExpressionUUID->"ebf094e1-882d-4d8c-804a-0d7e4eed420a",
  CellID->140411135],
-Cell[91638, 2371, 135, 2, 29, "Template",ExpressionUUID->"6d40d3de-5ebb-47e0-bd08-01bdad3c6d3a",
+Cell[95544, 2473, 135, 2, 29, "Template",ExpressionUUID->"6d40d3de-5ebb-47e0-bd08-01bdad3c6d3a",
  CellID->8216975]
 }, Closed]]
 }, Open  ]]

--- a/Paclet/Documentation/English/ReferencePages/Symbols/NonReciprocalAbelianBlochHamiltonianExpression.nb
+++ b/Paclet/Documentation/English/ReferencePages/Symbols/NonReciprocalAbelianBlochHamiltonianExpression.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[     89178,       2322]
-NotebookOptionsPosition[     78212,       2085]
-NotebookOutlinePosition[     78992,       2110]
-CellTagsIndexPosition[     78912,       2105]
+NotebookDataLength[    103841,       2636]
+NotebookOptionsPosition[     91801,       2377]
+NotebookOutlinePosition[     92579,       2402]
+CellTagsIndexPosition[     92499,       2397]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -21,7 +21,7 @@ Notebook[{
 
 Cell[CellGroupData[{
 Cell["NonReciprocalAbelianBlochHamiltonianExpression", "ObjectName",
- CellChangeTimes->{{3.9345316829462395`*^9, 3.9345316910471287`*^9}},
+ CellChangeTimes->{{3.93453168294624*^9, 3.934531691047129*^9}},
  CellID->487529978,ExpressionUUID->"e13727bc-dacc-4fb6-b263-63e32ad6c083"],
 
 Cell[TextData[{
@@ -41,7 +41,7 @@ NonReciprocalAbelianBlochHamiltonianExpression"], "[",
     StyleBox["hoppingsOpposite", "TI"], ",", 
     StyleBox["k", "TI"]}], "]"}]], "InlineFormula",ExpressionUUID->
   "5db1670b-08b9-4fa8-bf7b-75d3c7d32054"],
- " \[LineSeparator]constructs the Abelian Bloch Hamiltonian \
+ " \[LineSeparator]constructs the non-reciprocal Abelian Bloch Hamiltonian \
 \[ScriptCapitalH](",
  Cell[BoxData[
   StyleBox["k", "TI"]], "InlineFormula",ExpressionUUID->
@@ -89,7 +89,8 @@ NonReciprocalAbelianBlochHamiltonianExpression"], "[",
   3.906024500465488*^9, 3.906024508469338*^9}, {3.906025002658679*^9, 
   3.906025244939263*^9}, {3.906026796802244*^9, 3.90602680072703*^9}, {
   3.934509675976303*^9, 3.934509698167139*^9}, {3.934509731811102*^9, 
-  3.9345097342564297`*^9}, {3.9374208802584267`*^9, 3.9374209057520046`*^9}},
+  3.9345097342564297`*^9}, {3.937420880258427*^9, 3.9374209057520046`*^9}, {
+  3.9551672994322243`*^9, 3.9551673050423107`*^9}},
  CellID->19881515,ExpressionUUID->"9d01a708-6a9a-4a0b-84f1-164256a41ecf"],
 
 Cell[TextData[{
@@ -182,7 +183,7 @@ edge or a number if ",
  CellChangeTimes->{{3.9060266213652525`*^9, 3.906026659154008*^9}, {
    3.906026700789758*^9, 3.906026727330248*^9}, {3.906028366647201*^9, 
    3.9060283912422037`*^9}, 3.906028476610166*^9, {3.934472060666183*^9, 
-   3.934472111978956*^9}, {3.9374209118062477`*^9, 3.9374209225820103`*^9}},
+   3.934472111978956*^9}, {3.9374209118062477`*^9, 3.9374209225820107`*^9}},
  CellID->258865958,ExpressionUUID->"7b449629-e8dc-dd43-ba20-5ffdb044811a"],
 
 Cell[TextData[{
@@ -231,11 +232,12 @@ terms of the momentum components ",
 }], "Notes",
  CellChangeTimes->{{3.906026758611668*^9, 3.906026847094504*^9}, {
   3.934509788112643*^9, 3.934509794782414*^9}, {3.934531703291971*^9, 
-  3.9345317085123024`*^9}},
+  3.934531708512304*^9}},
  CellID->679798389,ExpressionUUID->"740bbe1c-6f24-48dd-8911-626dc1580f8d"],
 
-Cell["The following option can be given:", "Notes",
- CellChangeTimes->{{3.906026854624065*^9, 3.9060268604382353`*^9}},
+Cell["The following options can be given:", "Notes",
+ CellChangeTimes->{{3.906026854624065*^9, 3.9060268604382353`*^9}, 
+   3.955167531682272*^9},
  CellID->122405462,ExpressionUUID->"c22ece98-50cc-4c63-ac53-96ee03b7e01d"],
 
 Cell[BoxData[GridBox[{
@@ -421,10 +423,10 @@ AbelianBlochHamiltonianExpression"]], "InlineSeeAlsoFunction",
     "dc85d5f4-7a98-45de-8522-589a7ed082b5"], 
    DynamicModuleBox[{$CellContext`nbobj$$ = NotebookObject[
     "d13007c1-f945-4caf-9c39-96e1de350f63", 
-     "60dc9ae4-43d8-ce48-8e4d-9c34e81d3240"], $CellContext`cellobj$$ = 
+     "731de9ba-c41f-ee40-9589-aaf19c22e279"], $CellContext`cellobj$$ = 
     CellObject[
     "e4b2c6e8-2a34-43c4-ab33-420ee3451b24", 
-     "b643f5fd-8dd8-1541-8d03-4df6289ea262"]}, 
+     "21a4907a-f8a5-1f44-8ad5-c6f7f54caff6"]}, 
     TemplateBox[{
       GraphicsBox[{{
          Thickness[0.06], 
@@ -685,7 +687,8 @@ Cell[BoxData[
  CellID->677196106,ExpressionUUID->"6f664ba6-6c53-42b9-896f-a2581d917c9a"],
 
 Cell[TextData[{
- "Construct the Abelian Bloch Hamiltonian of a hopping model defined on an ",
+ "Construct the non-reciprocal Abelian Bloch Hamiltonian of a hopping model \
+defined on an ",
  Cell[BoxData[
   ButtonBox["HCModelGraph",
    BaseStyle->"Link",
@@ -710,7 +713,7 @@ amplitudes ",
  CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
    3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
    3.906028831115154*^9}, 3.934510258017254*^9, {3.9374209657175655`*^9, 
-   3.9374209782429676`*^9}},
+   3.937420978242968*^9}, {3.955167324515068*^9, 3.9551673283371525`*^9}},
  CellID->680708440,ExpressionUUID->"e3b8ece6-3cc9-4858-8f68-4b8698f8e5fe"],
 
 Cell[CellGroupData[{
@@ -916,7 +919,8 @@ Cell[BoxData[
  CellID->228953716,ExpressionUUID->"0acee9e9-b06e-44f6-8e0d-3416aee46a15"],
 
 Cell[TextData[{
- "Construct the Abelian Bloch Hamiltonian of a hopping model defined on an ",
+ "Construct the non-reciprocal Abelian Bloch Hamiltonian of a hopping model \
+defined on an ",
  Cell[BoxData[
   ButtonBox["HCModelGraph",
    BaseStyle->"Link",
@@ -936,7 +940,8 @@ amplitudes ",
  CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
    3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
    3.906028831115154*^9}, {3.906028997135098*^9, 3.906029000923377*^9}, 
-   3.9345103390559063`*^9, {3.937421005016327*^9, 3.9374210159177094`*^9}},
+   3.9345103390559063`*^9, {3.937421005016327*^9, 3.9374210159177094`*^9}, {
+   3.9551673567773075`*^9, 3.955167361081892*^9}},
  CellID->16699796,ExpressionUUID->"2b77b004-ee91-4f85-a423-e0925f110a86"],
 
 Cell[CellGroupData[{
@@ -979,9 +984,10 @@ Cell[BoxData[{
    3.906028853588249*^9, 3.906028970614804*^9}, {3.906029009568014*^9, 
    3.9060291359216547`*^9}, 3.906435166479804*^9, 3.918641100224955*^9, 
    3.918641526860538*^9, {3.934510346885731*^9, 3.934510363362161*^9}, {
-   3.934512248861981*^9, 3.934512249102097*^9}, {3.9374210186800976`*^9, 
-   3.9374210398644886`*^9}},
- CellLabel->"In[1]:=",
+   3.934512248861981*^9, 3.934512249102097*^9}, {3.937421018680098*^9, 
+   3.937421039864488*^9}, {3.955173113814621*^9, 3.955173117314657*^9}, {
+   3.9551741203647385`*^9, 3.9551741244945164`*^9}},
+ CellLabel->"In[6]:=",
  CellID->78835713,ExpressionUUID->"af5ddb53-5b80-49af-96c3-756fe4ccaec9"],
 
 Cell[BoxData[
@@ -1050,9 +1056,10 @@ Cell[BoxData[
        RowBox[{"\[ImaginaryI]", " ", 
         RowBox[{"k", "[", "4", "]"}]}]]}], ",", "1"}], "}"}]}], 
   "}"}]], "Output",
- CellChangeTimes->{{3.9345122365517464`*^9, 3.9345122365718365`*^9}},
- CellLabel->"Out[4]=",
- CellID->166628881,ExpressionUUID->"18ff5542-f76a-4ee3-ab97-6bd0aef4a220"]
+ CellChangeTimes->{{3.9345122365517464`*^9, 3.9345122365718365`*^9}, 
+   3.955173120594471*^9, 3.9551741279749165`*^9},
+ CellLabel->"Out[10]=",
+ CellID->140578249,ExpressionUUID->"2165acae-2d7c-f94d-a0ae-f1bbb8f98a70"]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
@@ -1965,12 +1972,297 @@ Cell[BoxData[
   $Line = 0; Null]], "ExampleSection",
  CellID->466091341,ExpressionUUID->"0d54ec61-ab7c-4802-a22b-16908247134f"],
 
+Cell[CellGroupData[{
+
 Cell[BoxData[
  InterpretationBox[Cell[
   "Properties & Relations", "ExampleSection",ExpressionUUID->
    "d2c40687-a256-4d79-95fb-efff9fa4fad3"],
   $Line = 0; Null]], "ExampleSection",
  CellID->113613961,ExpressionUUID->"ae535a9b-e8d7-4579-92e7-f72773096d65"],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ InterpretationBox[Cell[TextData[Cell[BoxData[
+   InterpretationBox[Cell[
+    "Multiple orbitals", "ExampleSubsection",ExpressionUUID->
+     "c5513a18-51ec-6b4b-8583-93beda4e94e7"],
+    $Line = 0; Null]],
+   CellChangeTimes->{{3.9060313294514136`*^9, 3.906031330419829*^9}, {
+    3.9374005375764217`*^9, 3.937400540021569*^9}},ExpressionUUID->
+   "44766c4b-8d80-594c-80a4-801bf27635a9"]], "ExampleSubsection",
+   ExpressionUUID->"932a1822-06fe-dc44-bcbc-56573a478e62"],
+  $Line = 0; Null]], "ExampleSubsection",
+ CellChangeTimes->{{3.9060313294514136`*^9, 3.906031330419829*^9}, {
+  3.937405053908352*^9, 3.937405065322071*^9}, {3.9551680429373455`*^9, 
+  3.95516805009239*^9}},
+ CellID->296669070,ExpressionUUID->"7e375bee-9264-784e-8fc9-b01785875e8b"],
+
+Cell[TextData[{
+ "Non-reciprocal Abelian Bloch Hamiltonians are constructed through a \
+generalization of the function  ",
+ Cell[BoxData[
+  ButtonBox["AbelianBlochHamiltonianExpression",
+   BaseStyle->"Link",
+   ButtonData->
+    "paclet:PatrickMLenggenhager/HyperBloch/ref/\
+AbelianBlochHamiltonianExpression"]], "InlineFormula",ExpressionUUID->
+  "32f2ef9a-7cd0-0740-9b12-754f932af0e0"],
+ ". As such, the onsite potential and the hopping amplitudes are specified \
+analogously. Crucially, the following convention is imposed:"
+}], "ExampleText",
+ CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
+   3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
+   3.906028831115154*^9}, {3.906028997135098*^9, 3.906029000923377*^9}, 
+   3.9345103390559063`*^9, {3.937421005016327*^9, 3.9374210159177094`*^9}, {
+   3.9551673567773075`*^9, 3.955167361081892*^9}, {3.955168934862646*^9, 
+   3.9551689986790257`*^9}, {3.9551691386825943`*^9, 
+   3.9551691946723156`*^9}, {3.955169256152302*^9, 3.9551694931826744`*^9}, {
+   3.955169586572748*^9, 3.9551697126776447`*^9}, {3.955169791552847*^9, 
+   3.9551697986726894`*^9}, {3.955169850973112*^9, 3.9551698519929733`*^9}, {
+   3.9551699271128254`*^9, 3.955170211827799*^9}, {3.955170242038122*^9, 
+   3.955170255833084*^9}, {3.955170301413376*^9, 3.9551703913169937`*^9}, {
+   3.955170445563442*^9, 3.9551705987731857`*^9}},
+ CellID->105689035,ExpressionUUID->"d0fa4c32-017f-6941-9e2b-bed568d07987"],
+
+Cell[TextData[{
+ "To specify the hopping matrix for the hopping amplitudes  ",
+ Cell[BoxData[
+  StyleBox["hoppingsOpposite", "TI"]], "InlineFormula",ExpressionUUID->
+  "0e8fca8e-2b1a-1a4d-a962-ab99b2a91003"],
+ " appropriately, the positions of the matrix entries for each pair of \
+orbitals is inherited from the hopping matrix ",
+ Cell[BoxData[
+  StyleBox["hoppingsCanonical", "TI"]], "InlineFormula",ExpressionUUID->
+  "0ce6055d-c1c5-7c43-ac06-2e4165c2fbb7"],
+ ". "
+}], "ExampleText",
+ CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
+   3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
+   3.906028831115154*^9}, {3.906028997135098*^9, 3.906029000923377*^9}, 
+   3.9345103390559063`*^9, {3.937421005016327*^9, 3.9374210159177094`*^9}, {
+   3.9551673567773075`*^9, 3.955167361081892*^9}, {3.955168934862646*^9, 
+   3.9551689986790257`*^9}, {3.9551691386825943`*^9, 
+   3.9551691946723156`*^9}, {3.955169256152302*^9, 3.9551694931826744`*^9}, {
+   3.955169586572748*^9, 3.9551697126776447`*^9}, {3.955169791552847*^9, 
+   3.9551697986726894`*^9}, {3.955169850973112*^9, 3.9551698519929733`*^9}, {
+   3.9551699271128254`*^9, 3.955170211827799*^9}, {3.955170242038122*^9, 
+   3.955170255833084*^9}, {3.955170301413376*^9, 3.9551703913169937`*^9}, {
+   3.955170445563442*^9, 3.955170745103998*^9}, {3.95517080197999*^9, 
+   3.955170813024542*^9}, {3.955171255916292*^9, 3.9551712615131607`*^9}, {
+   3.955172093403908*^9, 3.9551720938842525`*^9}},
+ CellID->709734105,ExpressionUUID->"de31d0fe-301c-a442-b6c2-0da829655420"],
+
+Cell[TextData[{
+ "For example, the non-reciprocal Abelian Bloch Hamiltonian of a hopping \
+model defined on an ",
+ Cell[BoxData[
+  ButtonBox["HCModelGraph",
+   BaseStyle->"Link",
+   ButtonData->"paclet:PatrickMLenggenhager/HyperBloch/ref/HCModelGraph"]], 
+  "InlineFormula",ExpressionUUID->"fbea9269-1c47-1947-8aee-b484267de34f"],
+ " (here the primitive cell of the {8,8} tessellation) with hopping \
+amplitudes ",
+ Cell[BoxData[
+  StyleBox["hoppingsCanonical", "TI"]], "InlineFormula",ExpressionUUID->
+  "24c49a96-7e81-d449-993b-8f1aed04f8b7"],
+ " in the canonical directions and ",
+ Cell[BoxData[
+  StyleBox["hoppingsOpposite", "TI"]], "InlineFormula",ExpressionUUID->
+  "af982acc-dbb3-1f4c-aa34-8fd11a4f6013"],
+ " in the opposite directions and two orbitals per site, using symbolic \
+arguments, is:"
+}], "ExampleText",
+ CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
+   3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
+   3.906028831115154*^9}, {3.906028997135098*^9, 3.906029000923377*^9}, 
+   3.9345103390559063`*^9, {3.937421005016327*^9, 3.9374210159177094`*^9}, {
+   3.9551673567773075`*^9, 3.955167361081892*^9}, {3.955169884838175*^9, 
+   3.955169900892893*^9}, {3.9551712636836224`*^9, 3.9551712747634583`*^9}, {
+   3.9551714818336887`*^9, 3.9551715032236137`*^9}, {3.955172112773716*^9, 
+   3.955172113753664*^9}},
+ CellID->105347582,ExpressionUUID->"efc5cb6f-fc63-7e4a-a77b-e01c3c1ceac3"],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[{
+ RowBox[{
+  RowBox[{"modelgraph", "=", 
+   RowBox[{"HCExampleData", "[", "\"\<{8,8}-tess_T2.6_3.hcm\>\"", "]"}]}], 
+  ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"onsite", "=", 
+   RowBox[{
+    RowBox[{"(", GridBox[{
+       {"0", 
+        RowBox[{"-", "t1"}]},
+       {"t1", "0"}
+      }], ")"}], "&"}]}], ";"}], "\n", 
+ RowBox[{
+  RowBox[{"hoppingsCanonical", "=", 
+   RowBox[{
+    RowBox[{
+     RowBox[{"-", "t2"}], 
+     RowBox[{"(", GridBox[{
+        {"0", "1"},
+        {"1", "0"}
+       }], ")"}]}], "&"}]}], ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"hoppingsOpposite", " ", "=", 
+   RowBox[{
+    RowBox[{"t2", 
+     RowBox[{"(", GridBox[{
+        {"0", "1"},
+        {"1", "0"}
+       }], ")"}]}], "&"}]}], ";"}], "\[IndentingNewLine]", 
+ RowBox[{"NonReciprocalAbelianBlochHamiltonianExpression", "[", 
+  RowBox[{"modelgraph", ",", 
+   RowBox[{"2", "&"}], ",", "onsite", ",", "hoppingsCanonical", ",", 
+   "hoppingsOpposite", ",", "k"}], "]"}]}], "Input",
+ CellChangeTimes->{{3.906027063408805*^9, 3.906027088319622*^9}, {
+   3.9060271833899145`*^9, 3.906027223799124*^9}, 3.906028315145218*^9, {
+   3.906028607996865*^9, 3.906028613837571*^9}, {3.9060286781196327`*^9, 
+   3.906028694807095*^9}, {3.906028732857873*^9, 3.906028753463425*^9}, {
+   3.906028853588249*^9, 3.906028970614804*^9}, {3.906029009568014*^9, 
+   3.9060291359216547`*^9}, 3.906435166479804*^9, 3.918641100224955*^9, 
+   3.918641526860538*^9, {3.934510346885731*^9, 3.934510363362161*^9}, {
+   3.934512248861981*^9, 3.934512249102097*^9}, {3.937421018680098*^9, 
+   3.937421039864488*^9}, 3.9551685771625175`*^9, {3.9551686636921463`*^9, 
+   3.9551686812375736`*^9}, {3.9551688907523804`*^9, 3.955168898442978*^9}, {
+   3.9551715089333115`*^9, 3.9551715174531784`*^9}, {3.9551722334739017`*^9, 
+   3.9551722813437862`*^9}, {3.9551731788246975`*^9, 
+   3.9551732107602386`*^9}, {3.955173241444565*^9, 3.9551732573395042`*^9}, {
+   3.9551736999744873`*^9, 3.955173717554676*^9}, {3.955173754074892*^9, 
+   3.9551737789347763`*^9}, {3.9551738764048176`*^9, 3.955173881875292*^9}, {
+   3.955173958940502*^9, 3.955173964274702*^9}, {3.955174224704588*^9, 
+   3.9551742286749134`*^9}, {3.955174273904991*^9, 3.9551742763650055`*^9}},
+ CellLabel->"In[1]:=",
+ CellID->448289478,ExpressionUUID->"afc51794-de33-a843-84c0-d8eb813a2698"],
+
+Cell[BoxData[
+ RowBox[{"{", 
+  RowBox[{
+   RowBox[{"{", 
+    RowBox[{"0", ",", 
+     RowBox[{
+      RowBox[{"-", "t1"}], "+", 
+      RowBox[{
+       RowBox[{"(", 
+        RowBox[{
+         SuperscriptBox["\[ExponentialE]", 
+          RowBox[{
+           RowBox[{"-", "\[ImaginaryI]"}], " ", 
+           RowBox[{"k", "[", "1", "]"}]}]], "-", 
+         SuperscriptBox["\[ExponentialE]", 
+          RowBox[{"\[ImaginaryI]", " ", 
+           RowBox[{"k", "[", "1", "]"}]}]], "+", 
+         SuperscriptBox["\[ExponentialE]", 
+          RowBox[{
+           RowBox[{"-", "\[ImaginaryI]"}], " ", 
+           RowBox[{"k", "[", "2", "]"}]}]], "-", 
+         SuperscriptBox["\[ExponentialE]", 
+          RowBox[{"\[ImaginaryI]", " ", 
+           RowBox[{"k", "[", "2", "]"}]}]], "+", 
+         SuperscriptBox["\[ExponentialE]", 
+          RowBox[{
+           RowBox[{"-", "\[ImaginaryI]"}], " ", 
+           RowBox[{"k", "[", "3", "]"}]}]], "-", 
+         SuperscriptBox["\[ExponentialE]", 
+          RowBox[{"\[ImaginaryI]", " ", 
+           RowBox[{"k", "[", "3", "]"}]}]], "+", 
+         SuperscriptBox["\[ExponentialE]", 
+          RowBox[{
+           RowBox[{"-", "\[ImaginaryI]"}], " ", 
+           RowBox[{"k", "[", "4", "]"}]}]], "-", 
+         SuperscriptBox["\[ExponentialE]", 
+          RowBox[{"\[ImaginaryI]", " ", 
+           RowBox[{"k", "[", "4", "]"}]}]]}], ")"}], " ", "t2"}]}]}], "}"}], 
+   ",", 
+   RowBox[{"{", 
+    RowBox[{
+     RowBox[{"t1", "+", 
+      RowBox[{
+       RowBox[{"(", 
+        RowBox[{
+         SuperscriptBox["\[ExponentialE]", 
+          RowBox[{
+           RowBox[{"-", "\[ImaginaryI]"}], " ", 
+           RowBox[{"k", "[", "1", "]"}]}]], "-", 
+         SuperscriptBox["\[ExponentialE]", 
+          RowBox[{"\[ImaginaryI]", " ", 
+           RowBox[{"k", "[", "1", "]"}]}]], "+", 
+         SuperscriptBox["\[ExponentialE]", 
+          RowBox[{
+           RowBox[{"-", "\[ImaginaryI]"}], " ", 
+           RowBox[{"k", "[", "2", "]"}]}]], "-", 
+         SuperscriptBox["\[ExponentialE]", 
+          RowBox[{"\[ImaginaryI]", " ", 
+           RowBox[{"k", "[", "2", "]"}]}]], "+", 
+         SuperscriptBox["\[ExponentialE]", 
+          RowBox[{
+           RowBox[{"-", "\[ImaginaryI]"}], " ", 
+           RowBox[{"k", "[", "3", "]"}]}]], "-", 
+         SuperscriptBox["\[ExponentialE]", 
+          RowBox[{"\[ImaginaryI]", " ", 
+           RowBox[{"k", "[", "3", "]"}]}]], "+", 
+         SuperscriptBox["\[ExponentialE]", 
+          RowBox[{
+           RowBox[{"-", "\[ImaginaryI]"}], " ", 
+           RowBox[{"k", "[", "4", "]"}]}]], "-", 
+         SuperscriptBox["\[ExponentialE]", 
+          RowBox[{"\[ImaginaryI]", " ", 
+           RowBox[{"k", "[", "4", "]"}]}]]}], ")"}], " ", "t2"}]}], ",", 
+     "0"}], "}"}]}], "}"}]], "Output",
+ CellChangeTimes->{{3.9345122365517464`*^9, 3.9345122365718365`*^9}, 
+   3.9551686897425213`*^9, 3.955168894992527*^9, 3.9551715580633907`*^9, 
+   3.9551731943463783`*^9, 3.9551732584047394`*^9, 3.9551737220747166`*^9, 
+   3.9551738227094727`*^9, 3.9551738833143463`*^9, 3.9551742297750053`*^9, 
+   3.9551742771349545`*^9, 3.9551753716726227`*^9},
+ CellLabel->"Out[5]=",
+ CellID->1351737,ExpressionUUID->"6f65396e-fec0-b440-ac40-9c94c63f6915"]
+}, Open  ]],
+
+Cell["\<\
+Specifically, we have set the mass terms of the orbitals to zero, the \
+intra-cell coupling to -t1 in the canonical direction and t1 in the opposite \
+direction and the inter-cell coupling to -t2  in the canonical direction and \
+t2 in the opposite direction.\
+\>", "ExampleText",
+ CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
+   3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
+   3.906028831115154*^9}, {3.906028997135098*^9, 3.906029000923377*^9}, 
+   3.9345103390559063`*^9, {3.937421005016327*^9, 3.9374210159177094`*^9}, {
+   3.9551673567773075`*^9, 3.955167361081892*^9}, {3.955169884838175*^9, 
+   3.955169900892893*^9}, {3.9551712636836224`*^9, 3.9551712747634583`*^9}, {
+   3.9551714818336887`*^9, 3.9551715032236137`*^9}, {3.955172112773716*^9, 
+   3.955172113753664*^9}, {3.955172958744713*^9, 3.9551729998145275`*^9}, {
+   3.9551738888346024`*^9, 3.955174072975092*^9}},
+ CellID->135010306,ExpressionUUID->"d0b215a8-271e-7748-8dce-b5f2ca7ba53d"],
+
+Cell[TextData[{
+ "Note, for the specification of the hopping matrix ",
+ Cell[BoxData[
+  StyleBox["hoppingsOpposite", "TI"]], "InlineFormula",ExpressionUUID->
+  "f664bbe0-fe48-724c-96e1-7e53d0b38ff9"],
+ " it is instructive to think of constructing an Abelian Bloch Hamiltonian \
+with adjusted hopping amplitudes. The location of the matrix entries, \
+signifying which orbitals are couped, are not to be adjusted."
+}], "ExampleText",
+ CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
+   3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
+   3.906028831115154*^9}, {3.906028997135098*^9, 3.906029000923377*^9}, 
+   3.9345103390559063`*^9, {3.937421005016327*^9, 3.9374210159177094`*^9}, {
+   3.9551673567773075`*^9, 3.955167361081892*^9}, {3.955169884838175*^9, 
+   3.955169900892893*^9}, {3.9551712636836224`*^9, 3.9551712747634583`*^9}, {
+   3.9551714818336887`*^9, 3.9551715032236137`*^9}, {3.9551715785834274`*^9, 
+   3.955171787968336*^9}, {3.9551718215979214`*^9, 3.955171921880068*^9}, {
+   3.955171980553753*^9, 3.95517204996364*^9}, {3.9551721380934505`*^9, 
+   3.955172210473549*^9}, {3.955172312600815*^9, 3.95517231343186*^9}, {
+   3.955172798924677*^9, 3.9551728555947685`*^9}},
+ CellID->359104851,ExpressionUUID->"5e0470fd-1dee-c445-84c1-352ca10dd65d"]
+}, Open  ]]
+}, Open  ]],
 
 Cell[BoxData[
  InterpretationBox[Cell[
@@ -2083,7 +2375,7 @@ Cell[BoxData[""], "Template",
 }, Closed]]
 }, Open  ]]
 },
-WindowSize->{1269, 652.5},
+WindowSize->{1269, 647},
 WindowMargins->{{0, Automatic}, {Automatic, 0}},
 TaggingRules-><|"Paclet" -> "PatrickMLenggenhager/HyperBloch"|>,
 FrontEndVersion->"14.0 for Microsoft Windows (64-bit) (December 12, 2023)",
@@ -2097,230 +2389,252 @@ ExpressionUUID->"d13007c1-f945-4caf-9c39-96e1de350f63"
 (*CellTagsOutline
 CellTagsIndex->{
  "ExtendedExamples"->{
-  Cell[39417, 1061, 487, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"f66a8592-336f-436f-a669-374caa490be8",
+  Cell[39782, 1068, 487, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"f66a8592-336f-436f-a669-374caa490be8",
    CellTags->"ExtendedExamples",
    CellID->326378688]}
  }
 *)
 (*CellTagsIndex
 CellTagsIndex->{
- {"ExtendedExamples", 78717, 2098}
+ {"ExtendedExamples", 92304, 2390}
  }
 *)
 (*NotebookFileOutline
 Notebook[{
 Cell[CellGroupData[{
-Cell[580, 22, 213, 2, 74, "ObjectName",ExpressionUUID->"e13727bc-dacc-4fb6-b263-63e32ad6c083",
+Cell[580, 22, 208, 2, 74, "ObjectName",ExpressionUUID->"e13727bc-dacc-4fb6-b263-63e32ad6c083",
  CellID->487529978],
-Cell[796, 26, 2762, 66, 154, "Usage",ExpressionUUID->"9d01a708-6a9a-4a0b-84f1-164256a41ecf",
+Cell[791, 26, 2828, 67, 155, "Usage",ExpressionUUID->"9d01a708-6a9a-4a0b-84f1-164256a41ecf",
  CellID->19881515],
-Cell[3561, 94, 1212, 30, 48, "Notes",ExpressionUUID->"3e5204e8-3be9-4da4-9501-5649808fc72a",
+Cell[3622, 95, 1212, 30, 48, "Notes",ExpressionUUID->"3e5204e8-3be9-4da4-9501-5649808fc72a",
  CellID->642025679],
-Cell[4776, 126, 1090, 28, 48, "Notes",ExpressionUUID->"b25c64ad-3301-4f8e-a559-da0473698204",
+Cell[4837, 127, 1090, 28, 48, "Notes",ExpressionUUID->"b25c64ad-3301-4f8e-a559-da0473698204",
  CellID->140612745],
-Cell[5869, 156, 1235, 29, 69, "Notes",ExpressionUUID->"7b449629-e8dc-dd43-ba20-5ffdb044811a",
+Cell[5930, 157, 1235, 29, 69, "Notes",ExpressionUUID->"7b449629-e8dc-dd43-ba20-5ffdb044811a",
  CellID->258865958],
-Cell[7107, 187, 1064, 27, 69, "Notes",ExpressionUUID->"e1151d60-8292-1342-b3de-89475e41ebd5",
+Cell[7168, 188, 1064, 27, 69, "Notes",ExpressionUUID->"e1151d60-8292-1342-b3de-89475e41ebd5",
  CellID->129485177],
-Cell[8174, 216, 807, 18, 49, "Notes",ExpressionUUID->"740bbe1c-6f24-48dd-8911-626dc1580f8d",
+Cell[8235, 217, 805, 18, 49, "Notes",ExpressionUUID->"740bbe1c-6f24-48dd-8911-626dc1580f8d",
  CellID->679798389],
-Cell[8984, 236, 194, 2, 27, "Notes",ExpressionUUID->"c22ece98-50cc-4c63-ac53-96ee03b7e01d",
+Cell[9043, 237, 221, 3, 27, "Notes",ExpressionUUID->"c22ece98-50cc-4c63-ac53-96ee03b7e01d",
  CellID->122405462],
-Cell[9181, 240, 1770, 41, 103, "3ColumnTableMod",ExpressionUUID->"f591d055-2723-4966-8f6e-7ff27d82b11a",
+Cell[9267, 242, 1770, 41, 103, "3ColumnTableMod",ExpressionUUID->"f591d055-2723-4966-8f6e-7ff27d82b11a",
  CellID->65923218]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[10988, 286, 435, 12, 40, "TechNotesSection",ExpressionUUID->"f47e3415-f834-4914-a486-b823af301d1d",
+Cell[11074, 288, 435, 12, 40, "TechNotesSection",ExpressionUUID->"f47e3415-f834-4914-a486-b823af301d1d",
  CellID->909304175],
-Cell[11426, 300, 265, 6, 19, "Tutorials",ExpressionUUID->"7fc3f6ab-32a9-4701-a8e3-f6735c45ed1e",
+Cell[11512, 302, 265, 6, 19, "Tutorials",ExpressionUUID->"7fc3f6ab-32a9-4701-a8e3-f6735c45ed1e",
  CellID->151400]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[11728, 311, 472, 13, 39, "RelatedLinksSection",ExpressionUUID->"02244713-76a0-4f33-b1e3-b8a5d51ca845",
+Cell[11814, 313, 472, 13, 39, "RelatedLinksSection",ExpressionUUID->"02244713-76a0-4f33-b1e3-b8a5d51ca845",
  CellID->668778174],
-Cell[12203, 326, 102, 1, 19, "RelatedLinks",ExpressionUUID->"ba862e54-c50d-4e86-b0e8-d37e37a51cd0",
+Cell[12289, 328, 102, 1, 19, "RelatedLinks",ExpressionUUID->"ba862e54-c50d-4e86-b0e8-d37e37a51cd0",
  CellID->31080045]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[12342, 332, 458, 13, 39, "SeeAlsoSection",ExpressionUUID->"4ba55984-5139-4fcd-9e53-1cad8de1caa8",
+Cell[12428, 334, 458, 13, 39, "SeeAlsoSection",ExpressionUUID->"4ba55984-5139-4fcd-9e53-1cad8de1caa8",
  CellID->171383757],
-Cell[12803, 347, 4471, 108, 61, "SeeAlso",ExpressionUUID->"4eb40240-d0ca-4d06-b0ca-4394e89ed113",
+Cell[12889, 349, 4471, 108, 61, "SeeAlso",ExpressionUUID->"4eb40240-d0ca-4d06-b0ca-4394e89ed113",
  CellID->705308221]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[17311, 460, 183, 2, 39, "MoreAboutSection",ExpressionUUID->"d2d8457c-dfa6-4bed-a65a-ca11a7fbcca3",
+Cell[17397, 462, 183, 2, 39, "MoreAboutSection",ExpressionUUID->"d2d8457c-dfa6-4bed-a65a-ca11a7fbcca3",
  CellID->695784319],
-Cell[17497, 464, 281, 6, 19, "MoreAbout",ExpressionUUID->"67e2307f-8548-4d7c-a334-5ac9c3a54950",
+Cell[17583, 466, 281, 6, 19, "MoreAbout",ExpressionUUID->"67e2307f-8548-4d7c-a334-5ac9c3a54950",
  CellID->542581366]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[17815, 475, 529, 14, 69, "ExamplesInitializationSection",ExpressionUUID->"9514d01e-d4b4-4058-86bd-f20fd3ab07bc",
+Cell[17901, 477, 529, 14, 69, "ExamplesInitializationSection",ExpressionUUID->"9514d01e-d4b4-4058-86bd-f20fd3ab07bc",
  CellID->99901568],
-Cell[18347, 491, 308, 5, 45, "ExampleInitialization",ExpressionUUID->"ce892e22-556e-4cda-aed6-4e3ba77f9c27",
+Cell[18433, 493, 308, 5, 45, "ExampleInitialization",ExpressionUUID->"ce892e22-556e-4cda-aed6-4e3ba77f9c27",
  CellID->75714804]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[18692, 501, 441, 12, 71, "PrimaryExamplesSection",ExpressionUUID->"cb04f553-66b7-482d-a771-988eed0afb9c",
+Cell[18778, 503, 441, 12, 71, "PrimaryExamplesSection",ExpressionUUID->"cb04f553-66b7-482d-a771-988eed0afb9c",
  CellID->11026314],
-Cell[19136, 515, 890, 15, 77, "ExampleText",ExpressionUUID->"fe456159-779a-40e4-b90c-50fbbbdafc5f",
+Cell[19222, 517, 890, 15, 77, "ExampleText",ExpressionUUID->"fe456159-779a-40e4-b90c-50fbbbdafc5f",
  CellID->82755364],
 Cell[CellGroupData[{
-Cell[20051, 534, 898, 17, 43, "Input",ExpressionUUID->"ac881db1-505d-44dd-8c11-29c4ababfcca",
+Cell[20137, 536, 898, 17, 43, "Input",ExpressionUUID->"ac881db1-505d-44dd-8c11-29c4ababfcca",
  CellID->2282893],
-Cell[20952, 553, 1293, 34, 28, "Output",ExpressionUUID->"f6de1f59-7e7d-430b-aa27-7d239cdd518b",
+Cell[21038, 555, 1293, 34, 28, "Output",ExpressionUUID->"f6de1f59-7e7d-430b-aa27-7d239cdd518b",
  CellID->596936726]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[22282, 592, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"0d27364f-6a4a-41cd-8346-79a61252b6a1",
+Cell[22368, 594, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"0d27364f-6a4a-41cd-8346-79a61252b6a1",
  CellID->359821871],
-Cell[22527, 599, 286, 4, 24, "ExampleText",ExpressionUUID->"fac98d31-9663-47af-a4e5-08d1ebcb9f63",
+Cell[22613, 601, 286, 4, 24, "ExampleText",ExpressionUUID->"fac98d31-9663-47af-a4e5-08d1ebcb9f63",
  CellID->36408547],
 Cell[CellGroupData[{
-Cell[22838, 607, 1060, 20, 43, "Input",ExpressionUUID->"95fcf837-6c1b-4329-8d21-6642a74e79a8",
+Cell[22924, 609, 1060, 20, 43, "Input",ExpressionUUID->"95fcf837-6c1b-4329-8d21-6642a74e79a8",
  CellID->633400500],
-Cell[23901, 629, 1555, 44, 49, "Output",ExpressionUUID->"21e14cea-9a0e-45cf-9db1-bbe834c721d1",
+Cell[23987, 631, 1555, 44, 49, "Output",ExpressionUUID->"21e14cea-9a0e-45cf-9db1-bbe834c721d1",
  CellID->384403571]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[25505, 679, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"6f664ba6-6c53-42b9-896f-a2581d917c9a",
+Cell[25591, 681, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"6f664ba6-6c53-42b9-896f-a2581d917c9a",
  CellID->677196106],
-Cell[25750, 686, 1283, 27, 79, "ExampleText",ExpressionUUID->"e3b8ece6-3cc9-4858-8f68-4b8698f8e5fe",
+Cell[25836, 688, 1346, 28, 79, "ExampleText",ExpressionUUID->"e3b8ece6-3cc9-4858-8f68-4b8698f8e5fe",
  CellID->680708440],
 Cell[CellGroupData[{
-Cell[27058, 717, 5159, 144, 310, "Input",ExpressionUUID->"a3ba0bbe-867d-49f6-930b-2f9ce301407e",
+Cell[27207, 720, 5159, 144, 310, "Input",ExpressionUUID->"a3ba0bbe-867d-49f6-930b-2f9ce301407e",
  CellID->262417576],
-Cell[32220, 863, 1489, 41, 28, "Output",ExpressionUUID->"efc29266-40ba-49be-a1cf-b84decb63afa",
+Cell[32369, 866, 1489, 41, 28, "Output",ExpressionUUID->"efc29266-40ba-49be-a1cf-b84decb63afa",
  CellID->1840780417]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[33758, 910, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"0acee9e9-b06e-44f6-8e0d-3416aee46a15",
+Cell[33907, 913, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"0acee9e9-b06e-44f6-8e0d-3416aee46a15",
  CellID->228953716],
-Cell[34003, 917, 1140, 22, 60, "ExampleText",ExpressionUUID->"2b77b004-ee91-4f85-a423-e0925f110a86",
+Cell[34152, 920, 1209, 24, 60, "ExampleText",ExpressionUUID->"2b77b004-ee91-4f85-a423-e0925f110a86",
  CellID->16699796],
 Cell[CellGroupData[{
-Cell[35168, 943, 1623, 41, 159, "Input",ExpressionUUID->"af5ddb53-5b80-49af-96c3-756fe4ccaec9",
+Cell[35386, 948, 1719, 42, 159, "Input",ExpressionUUID->"af5ddb53-5b80-49af-96c3-756fe4ccaec9",
  CellID->78835713],
-Cell[36794, 986, 2562, 68, 49, "Output",ExpressionUUID->"18ff5542-f76a-4ee3-ab97-6bd0aef4a220",
- CellID->166628881]
+Cell[37108, 992, 2613, 69, 49, "Output",ExpressionUUID->"2165acae-2d7c-f94d-a0ae-f1bbb8f98a70",
+ CellID->140578249]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[39417, 1061, 487, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"f66a8592-336f-436f-a669-374caa490be8",
+Cell[39782, 1068, 487, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"f66a8592-336f-436f-a669-374caa490be8",
  CellTags->"ExtendedExamples",
  CellID->326378688],
 Cell[CellGroupData[{
-Cell[39929, 1078, 241, 5, 35, "ExampleSection",ExpressionUUID->"da147fcf-b8f0-4218-9c13-c664b65b2c3a",
+Cell[40294, 1085, 241, 5, 35, "ExampleSection",ExpressionUUID->"da147fcf-b8f0-4218-9c13-c664b65b2c3a",
  CellID->452520281],
 Cell[CellGroupData[{
-Cell[40195, 1087, 182, 2, 24, "ExampleSubsection",ExpressionUUID->"d4a00df3-6032-46aa-8c43-08d318b86920",
+Cell[40560, 1094, 182, 2, 24, "ExampleSubsection",ExpressionUUID->"d4a00df3-6032-46aa-8c43-08d318b86920",
  CellID->198501545],
-Cell[40380, 1091, 327, 6, 41, "ExampleText",ExpressionUUID->"4e1748c6-5972-4e9d-a5d7-a6bba5e0c15b",
+Cell[40745, 1098, 327, 6, 41, "ExampleText",ExpressionUUID->"4e1748c6-5972-4e9d-a5d7-a6bba5e0c15b",
  CellID->293180495],
-Cell[40710, 1099, 628, 14, 43, "Input",ExpressionUUID->"b1a3429b-0a07-4f33-ae72-2428e5482c38",
+Cell[41075, 1106, 628, 14, 43, "Input",ExpressionUUID->"b1a3429b-0a07-4f33-ae72-2428e5482c38",
  CellID->407621152],
 Cell[CellGroupData[{
-Cell[41363, 1117, 454, 10, 25, "Input",ExpressionUUID->"e839607d-07d1-4235-ad2f-67cd3e6762a4",
+Cell[41728, 1124, 454, 10, 25, "Input",ExpressionUUID->"e839607d-07d1-4235-ad2f-67cd3e6762a4",
  CellID->244028921],
-Cell[41820, 1129, 450, 10, 24, "Output",ExpressionUUID->"043e71d8-dd3f-42f2-8453-5be428587ba1",
+Cell[42185, 1136, 450, 10, 24, "Output",ExpressionUUID->"043e71d8-dd3f-42f2-8453-5be428587ba1",
  CellID->1295901354]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[42307, 1144, 632, 14, 43, "Input",ExpressionUUID->"34767bf5-b825-c44d-907f-3ce5e271e699",
+Cell[42672, 1151, 632, 14, 43, "Input",ExpressionUUID->"34767bf5-b825-c44d-907f-3ce5e271e699",
  CellID->197552022],
-Cell[42942, 1160, 1989, 65, 64, "Output",ExpressionUUID->"99acf93f-1c04-8c4c-80fa-d7c02718cd11",
+Cell[43307, 1167, 1989, 65, 64, "Output",ExpressionUUID->"99acf93f-1c04-8c4c-80fa-d7c02718cd11",
  CellID->832281926]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[44968, 1230, 737, 14, 43, "Input",ExpressionUUID->"bc22d04e-4e96-e04a-b73a-128982c74e0b",
+Cell[45333, 1237, 737, 14, 43, "Input",ExpressionUUID->"bc22d04e-4e96-e04a-b73a-128982c74e0b",
  CellID->156019331],
-Cell[45708, 1246, 1910, 61, 64, "Output",ExpressionUUID->"5dad78ef-68c0-c248-abad-2a697c48a75c",
+Cell[46073, 1253, 1910, 61, 64, "Output",ExpressionUUID->"5dad78ef-68c0-c248-abad-2a697c48a75c",
  CellID->247750513]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[47655, 1312, 786, 13, 43, "Input",ExpressionUUID->"fa73fb48-6a75-8545-8bf7-3096919d7b42",
+Cell[48020, 1319, 786, 13, 43, "Input",ExpressionUUID->"fa73fb48-6a75-8545-8bf7-3096919d7b42",
  CellID->657327319],
-Cell[48444, 1327, 4814, 129, 108, "Output",ExpressionUUID->"f5986d47-a0bf-b343-b95d-5eb4e15b8adb",
+Cell[48809, 1334, 4814, 129, 108, "Output",ExpressionUUID->"f5986d47-a0bf-b343-b95d-5eb4e15b8adb",
  CellID->110703830]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
-Cell[53297, 1461, 264, 5, 35, "ExampleSection",ExpressionUUID->"b38c68de-babb-4527-9b5b-919b90448d9a",
+Cell[53662, 1468, 264, 5, 35, "ExampleSection",ExpressionUUID->"b38c68de-babb-4527-9b5b-919b90448d9a",
  CellID->112538656],
 Cell[CellGroupData[{
-Cell[53586, 1470, 243, 5, 23, "ExampleSection",ExpressionUUID->"d9560930-ab18-4795-8acc-798ab4243332",
+Cell[53951, 1477, 243, 5, 23, "ExampleSection",ExpressionUUID->"d9560930-ab18-4795-8acc-798ab4243332",
  CellID->476698288],
 Cell[CellGroupData[{
-Cell[53854, 1479, 317, 6, 26, "ExampleSubsection",ExpressionUUID->"7cec6767-bb80-4457-8716-b1658dd1e46a",
+Cell[54219, 1486, 317, 6, 26, "ExampleSubsection",ExpressionUUID->"7cec6767-bb80-4457-8716-b1658dd1e46a",
  CellID->200887691],
-Cell[54174, 1487, 276, 5, 24, "ExampleText",ExpressionUUID->"4f95c364-93f1-4778-af4e-1ca1ee6be804",
+Cell[54539, 1494, 276, 5, 24, "ExampleText",ExpressionUUID->"4f95c364-93f1-4778-af4e-1ca1ee6be804",
  CellID->654805157],
 Cell[CellGroupData[{
-Cell[54475, 1496, 1986, 48, 166, "Input",ExpressionUUID->"c74efb92-0269-794b-af7f-4b6829c7bb10",
+Cell[54840, 1503, 1986, 48, 166, "Input",ExpressionUUID->"c74efb92-0269-794b-af7f-4b6829c7bb10",
  CellID->671148953],
-Cell[56464, 1546, 4813, 129, 108, "Output",ExpressionUUID->"de8807a4-9d2a-174c-aa27-d4b4aaeae312",
+Cell[56829, 1553, 4813, 129, 108, "Output",ExpressionUUID->"de8807a4-9d2a-174c-aa27-d4b4aaeae312",
  CellID->1280785804]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[61326, 1681, 718, 13, 28, "ExampleSubsection",ExpressionUUID->"70c5f4f4-489a-465c-a365-a3a6bb3afe2d",
+Cell[61691, 1688, 718, 13, 28, "ExampleSubsection",ExpressionUUID->"70c5f4f4-489a-465c-a365-a3a6bb3afe2d",
  CellID->1036996805],
-Cell[62047, 1696, 411, 10, 26, "ExampleText",ExpressionUUID->"041cec4a-5956-4da6-8304-a081527c2538",
+Cell[62412, 1703, 411, 10, 26, "ExampleText",ExpressionUUID->"041cec4a-5956-4da6-8304-a081527c2538",
  CellID->1975506230],
 Cell[CellGroupData[{
-Cell[62483, 1710, 865, 19, 61, "Input",ExpressionUUID->"f384a361-0a20-4bcc-ac15-506b4cbc0d3b",
+Cell[62848, 1717, 865, 19, 61, "Input",ExpressionUUID->"f384a361-0a20-4bcc-ac15-506b4cbc0d3b",
  CellID->88541343],
-Cell[63351, 1731, 10683, 224, 53, "Output",ExpressionUUID->"3e6cc0ba-a89f-431d-8426-c1b7e5ad5225",
+Cell[63716, 1738, 10683, 224, 53, "Output",ExpressionUUID->"3e6cc0ba-a89f-431d-8426-c1b7e5ad5225",
  CellID->254211235]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
-Cell[74073, 1960, 248, 5, 35, "ExampleSection",ExpressionUUID->"0d54ec61-ab7c-4802-a22b-16908247134f",
+Cell[74438, 1967, 248, 5, 35, "ExampleSection",ExpressionUUID->"0d54ec61-ab7c-4802-a22b-16908247134f",
  CellID->466091341],
-Cell[74324, 1967, 258, 5, 23, "ExampleSection",ExpressionUUID->"ae535a9b-e8d7-4579-92e7-f72773096d65",
+Cell[CellGroupData[{
+Cell[74711, 1976, 258, 5, 23, "ExampleSection",ExpressionUUID->"ae535a9b-e8d7-4579-92e7-f72773096d65",
  CellID->113613961],
-Cell[74585, 1974, 251, 5, 23, "ExampleSection",ExpressionUUID->"0eceeb89-7d50-4592-9afe-7c312252d0fb",
+Cell[CellGroupData[{
+Cell[74994, 1985, 767, 14, 28, "ExampleSubsection",ExpressionUUID->"7e375bee-9264-784e-8fc9-b01785875e8b",
+ CellID->296669070],
+Cell[75764, 2001, 1472, 25, 60, "ExampleText",ExpressionUUID->"d0fa4c32-017f-6941-9e2b-bed568d07987",
+ CellID->105689035],
+Cell[77239, 2028, 1559, 26, 41, "ExampleText",ExpressionUUID->"de31d0fe-301c-a442-b6c2-0da829655420",
+ CellID->709734105],
+Cell[78801, 2056, 1444, 28, 77, "ExampleText",ExpressionUUID->"efc5cb6f-fc63-7e4a-a77b-e01c3c1ceac3",
+ CellID->105347582],
+Cell[CellGroupData[{
+Cell[80270, 2088, 2336, 52, 159, "Input",ExpressionUUID->"afc51794-de33-a843-84c0-d8eb813a2698",
+ CellID->448289478],
+Cell[82609, 2142, 3207, 80, 49, "Output",ExpressionUUID->"6f65396e-fec0-b440-ac40-9c94c63f6915",
+ CellID->1351737]
+}, Open  ]],
+Cell[85831, 2225, 1012, 15, 58, "ExampleText",ExpressionUUID->"d0b215a8-271e-7748-8dce-b5f2ca7ba53d",
+ CellID->135010306],
+Cell[86846, 2242, 1301, 20, 58, "ExampleText",ExpressionUUID->"5e0470fd-1dee-c445-84c1-352ca10dd65d",
+ CellID->359104851]
+}, Open  ]]
+}, Open  ]],
+Cell[88174, 2266, 251, 5, 35, "ExampleSection",ExpressionUUID->"0eceeb89-7d50-4592-9afe-7c312252d0fb",
  CellID->594336563],
-Cell[74839, 1981, 256, 5, 23, "ExampleSection",ExpressionUUID->"3232c9e5-853c-43cf-a0c3-cece249b6374",
+Cell[88428, 2273, 256, 5, 23, "ExampleSection",ExpressionUUID->"3232c9e5-853c-43cf-a0c3-cece249b6374",
  CellID->763924802],
-Cell[75098, 1988, 248, 5, 23, "ExampleSection",ExpressionUUID->"335741ac-c3bf-4f98-b769-2a015f5bbb0e",
+Cell[88687, 2280, 248, 5, 23, "ExampleSection",ExpressionUUID->"335741ac-c3bf-4f98-b769-2a015f5bbb0e",
  CellID->76990128]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[75383, 1998, 109, 1, 72, "MetadataSection",ExpressionUUID->"04cac98b-4434-4558-bb5c-a50bffbaf3c6",
+Cell[88972, 2290, 109, 1, 72, "MetadataSection",ExpressionUUID->"04cac98b-4434-4558-bb5c-a50bffbaf3c6",
  CellID->42901253],
-Cell[75495, 2001, 473, 12, 26, "History",ExpressionUUID->"a9449086-5e97-4202-a957-8ef347936728",
+Cell[89084, 2293, 473, 12, 26, "History",ExpressionUUID->"a9449086-5e97-4202-a957-8ef347936728",
  CellID->969934],
 Cell[CellGroupData[{
-Cell[75993, 2017, 484, 13, 21, "CategorizationSection",ExpressionUUID->"df9aef4c-2850-49c2-a631-981bc53613de",
+Cell[89582, 2309, 484, 13, 21, "CategorizationSection",ExpressionUUID->"df9aef4c-2850-49c2-a631-981bc53613de",
  CellID->155892578],
-Cell[76480, 2032, 134, 2, 35, "Categorization",ExpressionUUID->"37577286-8a2e-4690-95d1-258cd136aac3",
+Cell[90069, 2324, 134, 2, 35, "Categorization",ExpressionUUID->"37577286-8a2e-4690-95d1-258cd136aac3",
  CellID->379313778],
-Cell[76617, 2036, 159, 2, 35, "Categorization",ExpressionUUID->"15fdabe5-69c0-4859-8ec5-136948b0dc35",
+Cell[90206, 2328, 159, 2, 35, "Categorization",ExpressionUUID->"15fdabe5-69c0-4859-8ec5-136948b0dc35",
  CellID->123752965],
-Cell[76779, 2040, 156, 2, 35, "Categorization",ExpressionUUID->"c4965993-9dd5-4758-bf37-c7cd4d83d488",
+Cell[90368, 2332, 156, 2, 35, "Categorization",ExpressionUUID->"c4965993-9dd5-4758-bf37-c7cd4d83d488",
  CellID->207073079],
-Cell[76938, 2044, 277, 6, 35, "Categorization",ExpressionUUID->"bb49b832-e02e-40af-9542-ed5332d2229c",
+Cell[90527, 2336, 277, 6, 35, "Categorization",ExpressionUUID->"bb49b832-e02e-40af-9542-ed5332d2229c",
  CellID->485781109]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[77252, 2055, 109, 1, 31, "KeywordsSection",ExpressionUUID->"b9218ebb-8180-446d-816f-0ae498757f49",
+Cell[90841, 2347, 109, 1, 31, "KeywordsSection",ExpressionUUID->"b9218ebb-8180-446d-816f-0ae498757f49",
  CellID->55111812],
-Cell[77364, 2058, 98, 1, 21, "Keywords",ExpressionUUID->"ef98b38b-9a15-4564-a72a-1ac60a848bb4",
+Cell[90953, 2350, 98, 1, 21, "Keywords",ExpressionUUID->"ef98b38b-9a15-4564-a72a-1ac60a848bb4",
  CellID->78694749]
 }, Closed]],
 Cell[CellGroupData[{
-Cell[77499, 2064, 119, 1, 21, "TemplatesSection",ExpressionUUID->"fc1f065b-1492-425c-99fa-0fbdcd783aa2",
+Cell[91088, 2356, 119, 1, 21, "TemplatesSection",ExpressionUUID->"fc1f065b-1492-425c-99fa-0fbdcd783aa2",
  CellID->272215535],
-Cell[77621, 2067, 148, 2, 29, "Template",ExpressionUUID->"78c4c51d-f3aa-458d-8e24-a157e274b180",
+Cell[91210, 2359, 148, 2, 29, "Template",ExpressionUUID->"78c4c51d-f3aa-458d-8e24-a157e274b180",
  CellID->476199561],
-Cell[77772, 2071, 136, 2, 29, "Template",ExpressionUUID->"b58c10d5-6253-4796-b2f6-1caf21f791fc",
+Cell[91361, 2363, 136, 2, 29, "Template",ExpressionUUID->"b58c10d5-6253-4796-b2f6-1caf21f791fc",
  CellID->39443153],
-Cell[77911, 2075, 135, 2, 29, "Template",ExpressionUUID->"ebf094e1-882d-4d8c-804a-0d7e4eed420a",
+Cell[91500, 2367, 135, 2, 29, "Template",ExpressionUUID->"ebf094e1-882d-4d8c-804a-0d7e4eed420a",
  CellID->140411135],
-Cell[78049, 2079, 135, 2, 29, "Template",ExpressionUUID->"6d40d3de-5ebb-47e0-bd08-01bdad3c6d3a",
+Cell[91638, 2371, 135, 2, 29, "Template",ExpressionUUID->"6d40d3de-5ebb-47e0-bd08-01bdad3c6d3a",
  CellID->8216975]
 }, Closed]]
 }, Open  ]]

--- a/Paclet/Documentation/English/ReferencePages/Symbols/NonReciprocalAbelianBlochHamiltonianExpression.nb
+++ b/Paclet/Documentation/English/ReferencePages/Symbols/NonReciprocalAbelianBlochHamiltonianExpression.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[    108105,       2744]
-NotebookOptionsPosition[     95707,       2479]
-NotebookOutlinePosition[     96491,       2504]
-CellTagsIndexPosition[     96411,       2499]
+NotebookDataLength[    108208,       2746]
+NotebookOptionsPosition[     95810,       2481]
+NotebookOutlinePosition[     96594,       2506]
+CellTagsIndexPosition[     96514,       2501]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -280,14 +280,15 @@ Cell[BoxData[
         {
          RowBox[{
           SubscriptBox["b", "i"], "\[Rule]", 
-          SubscriptBox["b", "j"]}], 
+          SubscriptBox["a", "j"]}], 
          RowBox[{
           SubscriptBox["b", "i"], "\[Rule]", 
           SubscriptBox["b", "j"]}]}
        }], ")"}], "&"}]}], ";"}], " "}]], "Notes",
  CellChangeTimes->{{3.9594190921442356`*^9, 3.9594191869209785`*^9}, {
    3.9594199305607395`*^9, 3.959419942131056*^9}, 3.9594199844307747`*^9, {
-   3.959420111086876*^9, 3.9594201114812164`*^9}, 3.959420152732893*^9},
+   3.959420111086876*^9, 3.9594201114812164`*^9}, 3.959420152732893*^9, {
+   3.9596605259443874`*^9, 3.959660526363762*^9}},
  CellID->207376718,ExpressionUUID->"1671ed16-39a8-f84a-a5e7-5d09eddfa739"],
 
 Cell[TextData[Cell[BoxData[
@@ -305,7 +306,7 @@ Cell[TextData[Cell[BoxData[
        {
         RowBox[{
          SubscriptBox["b", "i"], "\[LeftArrow]", 
-         SubscriptBox["b", "j"]}], 
+         SubscriptBox["a", "j"]}], 
         RowBox[{
          SubscriptBox["b", "i"], "\[LeftArrow]", 
          SubscriptBox["b", "j"]}]}
@@ -314,7 +315,8 @@ Cell[TextData[Cell[BoxData[
   3.9594199305607395`*^9, 
   3.959419942131056*^9}},ExpressionUUID->"8ff0a281-19c1-f348-9852-\
 6195910c8754"]], "Notes",
- CellChangeTimes->{{3.959420522251034*^9, 3.9594205393492985`*^9}},
+ CellChangeTimes->{{3.959420522251034*^9, 3.9594205393492985`*^9}, {
+  3.9596605282048054`*^9, 3.959660528316799*^9}},
  CellID->396819643,ExpressionUUID->"0e8e3364-61e7-6942-8a3f-0ff75a294039"],
 
 Cell[TextData[{
@@ -525,10 +527,10 @@ AbelianBlochHamiltonianExpression"]], "InlineSeeAlsoFunction",
     "dc85d5f4-7a98-45de-8522-589a7ed082b5"], 
    DynamicModuleBox[{$CellContext`nbobj$$ = NotebookObject[
     "d13007c1-f945-4caf-9c39-96e1de350f63", 
-     "6d1e3cfd-5829-c94a-986a-eb01c6785923"], $CellContext`cellobj$$ = 
+     "96006183-57d6-2b49-9193-1413d6814bd6"], $CellContext`cellobj$$ = 
     CellObject[
     "e4b2c6e8-2a34-43c4-ab33-420ee3451b24", 
-     "52796c7d-dc94-3740-97d4-d100b6caf4f5"]}, 
+     "50ad7ece-dfc1-f84d-b83b-fbe461008deb"]}, 
     TemplateBox[{
       GraphicsBox[{{
          Thickness[0.06], 
@@ -2491,14 +2493,14 @@ ExpressionUUID->"d13007c1-f945-4caf-9c39-96e1de350f63"
 (*CellTagsOutline
 CellTagsIndex->{
  "ExtendedExamples"->{
-  Cell[43688, 1170, 487, 13, 56, "ExtendedExamplesSection",ExpressionUUID->"f66a8592-336f-436f-a669-374caa490be8",
+  Cell[43791, 1172, 487, 13, 56, "ExtendedExamplesSection",ExpressionUUID->"f66a8592-336f-436f-a669-374caa490be8",
    CellTags->"ExtendedExamples",
    CellID->326378688]}
  }
 *)
 (*CellTagsIndex
 CellTagsIndex->{
- {"ExtendedExamples", 96216, 2492}
+ {"ExtendedExamples", 96319, 2494}
  }
 *)
 (*NotebookFileOutline
@@ -2518,231 +2520,231 @@ Cell[7168, 188, 1064, 27, 67, "Notes",ExpressionUUID->"e1151d60-8292-1342-b3de-8
  CellID->129485177],
 Cell[8235, 217, 2105, 47, 156, "Notes",ExpressionUUID->"fa3260dd-a9d7-f943-a61c-61a0b29eaba0",
  CellID->311370265],
-Cell[10343, 266, 882, 24, 41, "Notes",ExpressionUUID->"1671ed16-39a8-f84a-a5e7-5d09eddfa739",
+Cell[10343, 266, 934, 25, 41, "Notes",ExpressionUUID->"1671ed16-39a8-f84a-a5e7-5d09eddfa739",
  CellID->207376718],
-Cell[11228, 292, 910, 25, 41, "Notes",ExpressionUUID->"0e8e3364-61e7-6942-8a3f-0ff75a294039",
+Cell[11280, 293, 961, 26, 41, "Notes",ExpressionUUID->"0e8e3364-61e7-6942-8a3f-0ff75a294039",
  CellID->396819643],
-Cell[12141, 319, 805, 18, 46, "Notes",ExpressionUUID->"740bbe1c-6f24-48dd-8911-626dc1580f8d",
+Cell[12244, 321, 805, 18, 46, "Notes",ExpressionUUID->"740bbe1c-6f24-48dd-8911-626dc1580f8d",
  CellID->679798389],
-Cell[12949, 339, 221, 3, 26, "Notes",ExpressionUUID->"c22ece98-50cc-4c63-ac53-96ee03b7e01d",
+Cell[13052, 341, 221, 3, 26, "Notes",ExpressionUUID->"c22ece98-50cc-4c63-ac53-96ee03b7e01d",
  CellID->122405462],
-Cell[13173, 344, 1770, 41, 87, "3ColumnTableMod",ExpressionUUID->"f591d055-2723-4966-8f6e-7ff27d82b11a",
+Cell[13276, 346, 1770, 41, 87, "3ColumnTableMod",ExpressionUUID->"f591d055-2723-4966-8f6e-7ff27d82b11a",
  CellID->65923218]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[14980, 390, 435, 12, 39, "TechNotesSection",ExpressionUUID->"f47e3415-f834-4914-a486-b823af301d1d",
+Cell[15083, 392, 435, 12, 39, "TechNotesSection",ExpressionUUID->"f47e3415-f834-4914-a486-b823af301d1d",
  CellID->909304175],
-Cell[15418, 404, 265, 6, 17, "Tutorials",ExpressionUUID->"7fc3f6ab-32a9-4701-a8e3-f6735c45ed1e",
+Cell[15521, 406, 265, 6, 17, "Tutorials",ExpressionUUID->"7fc3f6ab-32a9-4701-a8e3-f6735c45ed1e",
  CellID->151400]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[15720, 415, 472, 13, 38, "RelatedLinksSection",ExpressionUUID->"02244713-76a0-4f33-b1e3-b8a5d51ca845",
+Cell[15823, 417, 472, 13, 38, "RelatedLinksSection",ExpressionUUID->"02244713-76a0-4f33-b1e3-b8a5d51ca845",
  CellID->668778174],
-Cell[16195, 430, 102, 1, 17, "RelatedLinks",ExpressionUUID->"ba862e54-c50d-4e86-b0e8-d37e37a51cd0",
+Cell[16298, 432, 102, 1, 17, "RelatedLinks",ExpressionUUID->"ba862e54-c50d-4e86-b0e8-d37e37a51cd0",
  CellID->31080045]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[16334, 436, 458, 13, 38, "SeeAlsoSection",ExpressionUUID->"4ba55984-5139-4fcd-9e53-1cad8de1caa8",
+Cell[16437, 438, 458, 13, 38, "SeeAlsoSection",ExpressionUUID->"4ba55984-5139-4fcd-9e53-1cad8de1caa8",
  CellID->171383757],
-Cell[16795, 451, 4471, 108, 50, "SeeAlso",ExpressionUUID->"4eb40240-d0ca-4d06-b0ca-4394e89ed113",
+Cell[16898, 453, 4471, 108, 50, "SeeAlso",ExpressionUUID->"4eb40240-d0ca-4d06-b0ca-4394e89ed113",
  CellID->705308221]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[21303, 564, 183, 2, 37, "MoreAboutSection",ExpressionUUID->"d2d8457c-dfa6-4bed-a65a-ca11a7fbcca3",
+Cell[21406, 566, 183, 2, 37, "MoreAboutSection",ExpressionUUID->"d2d8457c-dfa6-4bed-a65a-ca11a7fbcca3",
  CellID->695784319],
-Cell[21489, 568, 281, 6, 17, "MoreAbout",ExpressionUUID->"67e2307f-8548-4d7c-a334-5ac9c3a54950",
+Cell[21592, 570, 281, 6, 17, "MoreAbout",ExpressionUUID->"67e2307f-8548-4d7c-a334-5ac9c3a54950",
  CellID->542581366]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[21807, 579, 529, 14, 68, "ExamplesInitializationSection",ExpressionUUID->"9514d01e-d4b4-4058-86bd-f20fd3ab07bc",
+Cell[21910, 581, 529, 14, 68, "ExamplesInitializationSection",ExpressionUUID->"9514d01e-d4b4-4058-86bd-f20fd3ab07bc",
  CellID->99901568],
-Cell[22339, 595, 308, 5, 45, "ExampleInitialization",ExpressionUUID->"ce892e22-556e-4cda-aed6-4e3ba77f9c27",
+Cell[22442, 597, 308, 5, 45, "ExampleInitialization",ExpressionUUID->"ce892e22-556e-4cda-aed6-4e3ba77f9c27",
  CellID->75714804]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[22684, 605, 441, 12, 69, "PrimaryExamplesSection",ExpressionUUID->"cb04f553-66b7-482d-a771-988eed0afb9c",
+Cell[22787, 607, 441, 12, 69, "PrimaryExamplesSection",ExpressionUUID->"cb04f553-66b7-482d-a771-988eed0afb9c",
  CellID->11026314],
-Cell[23128, 619, 890, 15, 71, "ExampleText",ExpressionUUID->"fe456159-779a-40e4-b90c-50fbbbdafc5f",
+Cell[23231, 621, 890, 15, 71, "ExampleText",ExpressionUUID->"fe456159-779a-40e4-b90c-50fbbbdafc5f",
  CellID->82755364],
 Cell[CellGroupData[{
-Cell[24043, 638, 898, 17, 42, "Input",ExpressionUUID->"ac881db1-505d-44dd-8c11-29c4ababfcca",
+Cell[24146, 640, 898, 17, 42, "Input",ExpressionUUID->"ac881db1-505d-44dd-8c11-29c4ababfcca",
  CellID->2282893],
-Cell[24944, 657, 1293, 34, 26, "Output",ExpressionUUID->"f6de1f59-7e7d-430b-aa27-7d239cdd518b",
+Cell[25047, 659, 1293, 34, 26, "Output",ExpressionUUID->"f6de1f59-7e7d-430b-aa27-7d239cdd518b",
  CellID->596936726]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[26274, 696, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"0d27364f-6a4a-41cd-8346-79a61252b6a1",
+Cell[26377, 698, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"0d27364f-6a4a-41cd-8346-79a61252b6a1",
  CellID->359821871],
-Cell[26519, 703, 286, 4, 23, "ExampleText",ExpressionUUID->"fac98d31-9663-47af-a4e5-08d1ebcb9f63",
+Cell[26622, 705, 286, 4, 23, "ExampleText",ExpressionUUID->"fac98d31-9663-47af-a4e5-08d1ebcb9f63",
  CellID->36408547],
 Cell[CellGroupData[{
-Cell[26830, 711, 1060, 20, 42, "Input",ExpressionUUID->"95fcf837-6c1b-4329-8d21-6642a74e79a8",
+Cell[26933, 713, 1060, 20, 42, "Input",ExpressionUUID->"95fcf837-6c1b-4329-8d21-6642a74e79a8",
  CellID->633400500],
-Cell[27893, 733, 1555, 44, 47, "Output",ExpressionUUID->"21e14cea-9a0e-45cf-9db1-bbe834c721d1",
+Cell[27996, 735, 1555, 44, 47, "Output",ExpressionUUID->"21e14cea-9a0e-45cf-9db1-bbe834c721d1",
  CellID->384403571]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[29497, 783, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"6f664ba6-6c53-42b9-896f-a2581d917c9a",
+Cell[29600, 785, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"6f664ba6-6c53-42b9-896f-a2581d917c9a",
  CellID->677196106],
-Cell[29742, 790, 1346, 28, 71, "ExampleText",ExpressionUUID->"e3b8ece6-3cc9-4858-8f68-4b8698f8e5fe",
+Cell[29845, 792, 1346, 28, 71, "ExampleText",ExpressionUUID->"e3b8ece6-3cc9-4858-8f68-4b8698f8e5fe",
  CellID->680708440],
 Cell[CellGroupData[{
-Cell[31113, 822, 5159, 144, 309, "Input",ExpressionUUID->"a3ba0bbe-867d-49f6-930b-2f9ce301407e",
+Cell[31216, 824, 5159, 144, 309, "Input",ExpressionUUID->"a3ba0bbe-867d-49f6-930b-2f9ce301407e",
  CellID->262417576],
-Cell[36275, 968, 1489, 41, 26, "Output",ExpressionUUID->"efc29266-40ba-49be-a1cf-b84decb63afa",
+Cell[36378, 970, 1489, 41, 26, "Output",ExpressionUUID->"efc29266-40ba-49be-a1cf-b84decb63afa",
  CellID->1840780417]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[37813, 1015, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"0acee9e9-b06e-44f6-8e0d-3416aee46a15",
+Cell[37916, 1017, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"0acee9e9-b06e-44f6-8e0d-3416aee46a15",
  CellID->228953716],
-Cell[38058, 1022, 1209, 24, 55, "ExampleText",ExpressionUUID->"2b77b004-ee91-4f85-a423-e0925f110a86",
+Cell[38161, 1024, 1209, 24, 55, "ExampleText",ExpressionUUID->"2b77b004-ee91-4f85-a423-e0925f110a86",
  CellID->16699796],
 Cell[CellGroupData[{
-Cell[39292, 1050, 1719, 42, 158, "Input",ExpressionUUID->"af5ddb53-5b80-49af-96c3-756fe4ccaec9",
+Cell[39395, 1052, 1719, 42, 158, "Input",ExpressionUUID->"af5ddb53-5b80-49af-96c3-756fe4ccaec9",
  CellID->78835713],
-Cell[41014, 1094, 2613, 69, 47, "Output",ExpressionUUID->"2165acae-2d7c-f94d-a0ae-f1bbb8f98a70",
+Cell[41117, 1096, 2613, 69, 47, "Output",ExpressionUUID->"2165acae-2d7c-f94d-a0ae-f1bbb8f98a70",
  CellID->140578249]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[43688, 1170, 487, 13, 56, "ExtendedExamplesSection",ExpressionUUID->"f66a8592-336f-436f-a669-374caa490be8",
+Cell[43791, 1172, 487, 13, 56, "ExtendedExamplesSection",ExpressionUUID->"f66a8592-336f-436f-a669-374caa490be8",
  CellTags->"ExtendedExamples",
  CellID->326378688],
 Cell[CellGroupData[{
-Cell[44200, 1187, 241, 5, 32, "ExampleSection",ExpressionUUID->"da147fcf-b8f0-4218-9c13-c664b65b2c3a",
+Cell[44303, 1189, 241, 5, 32, "ExampleSection",ExpressionUUID->"da147fcf-b8f0-4218-9c13-c664b65b2c3a",
  CellID->452520281],
 Cell[CellGroupData[{
-Cell[44466, 1196, 182, 2, 23, "ExampleSubsection",ExpressionUUID->"d4a00df3-6032-46aa-8c43-08d318b86920",
+Cell[44569, 1198, 182, 2, 23, "ExampleSubsection",ExpressionUUID->"d4a00df3-6032-46aa-8c43-08d318b86920",
  CellID->198501545],
-Cell[44651, 1200, 327, 6, 39, "ExampleText",ExpressionUUID->"4e1748c6-5972-4e9d-a5d7-a6bba5e0c15b",
+Cell[44754, 1202, 327, 6, 39, "ExampleText",ExpressionUUID->"4e1748c6-5972-4e9d-a5d7-a6bba5e0c15b",
  CellID->293180495],
-Cell[44981, 1208, 628, 14, 42, "Input",ExpressionUUID->"b1a3429b-0a07-4f33-ae72-2428e5482c38",
+Cell[45084, 1210, 628, 14, 42, "Input",ExpressionUUID->"b1a3429b-0a07-4f33-ae72-2428e5482c38",
  CellID->407621152],
 Cell[CellGroupData[{
-Cell[45634, 1226, 454, 10, 25, "Input",ExpressionUUID->"e839607d-07d1-4235-ad2f-67cd3e6762a4",
+Cell[45737, 1228, 454, 10, 25, "Input",ExpressionUUID->"e839607d-07d1-4235-ad2f-67cd3e6762a4",
  CellID->244028921],
-Cell[46091, 1238, 450, 10, 24, "Output",ExpressionUUID->"043e71d8-dd3f-42f2-8453-5be428587ba1",
+Cell[46194, 1240, 450, 10, 24, "Output",ExpressionUUID->"043e71d8-dd3f-42f2-8453-5be428587ba1",
  CellID->1295901354]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[46578, 1253, 632, 14, 42, "Input",ExpressionUUID->"34767bf5-b825-c44d-907f-3ce5e271e699",
+Cell[46681, 1255, 632, 14, 42, "Input",ExpressionUUID->"34767bf5-b825-c44d-907f-3ce5e271e699",
  CellID->197552022],
-Cell[47213, 1269, 1989, 65, 62, "Output",ExpressionUUID->"99acf93f-1c04-8c4c-80fa-d7c02718cd11",
+Cell[47316, 1271, 1989, 65, 62, "Output",ExpressionUUID->"99acf93f-1c04-8c4c-80fa-d7c02718cd11",
  CellID->832281926]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[49239, 1339, 737, 14, 42, "Input",ExpressionUUID->"bc22d04e-4e96-e04a-b73a-128982c74e0b",
+Cell[49342, 1341, 737, 14, 42, "Input",ExpressionUUID->"bc22d04e-4e96-e04a-b73a-128982c74e0b",
  CellID->156019331],
-Cell[49979, 1355, 1910, 61, 62, "Output",ExpressionUUID->"5dad78ef-68c0-c248-abad-2a697c48a75c",
+Cell[50082, 1357, 1910, 61, 62, "Output",ExpressionUUID->"5dad78ef-68c0-c248-abad-2a697c48a75c",
  CellID->247750513]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[51926, 1421, 786, 13, 42, "Input",ExpressionUUID->"fa73fb48-6a75-8545-8bf7-3096919d7b42",
+Cell[52029, 1423, 786, 13, 42, "Input",ExpressionUUID->"fa73fb48-6a75-8545-8bf7-3096919d7b42",
  CellID->657327319],
-Cell[52715, 1436, 4814, 129, 106, "Output",ExpressionUUID->"f5986d47-a0bf-b343-b95d-5eb4e15b8adb",
+Cell[52818, 1438, 4814, 129, 106, "Output",ExpressionUUID->"f5986d47-a0bf-b343-b95d-5eb4e15b8adb",
  CellID->110703830]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
-Cell[57568, 1570, 264, 5, 32, "ExampleSection",ExpressionUUID->"b38c68de-babb-4527-9b5b-919b90448d9a",
+Cell[57671, 1572, 264, 5, 32, "ExampleSection",ExpressionUUID->"b38c68de-babb-4527-9b5b-919b90448d9a",
  CellID->112538656],
 Cell[CellGroupData[{
-Cell[57857, 1579, 243, 5, 20, "ExampleSection",ExpressionUUID->"d9560930-ab18-4795-8acc-798ab4243332",
+Cell[57960, 1581, 243, 5, 20, "ExampleSection",ExpressionUUID->"d9560930-ab18-4795-8acc-798ab4243332",
  CellID->476698288],
 Cell[CellGroupData[{
-Cell[58125, 1588, 317, 6, 23, "ExampleSubsection",ExpressionUUID->"7cec6767-bb80-4457-8716-b1658dd1e46a",
+Cell[58228, 1590, 317, 6, 23, "ExampleSubsection",ExpressionUUID->"7cec6767-bb80-4457-8716-b1658dd1e46a",
  CellID->200887691],
-Cell[58445, 1596, 276, 5, 23, "ExampleText",ExpressionUUID->"4f95c364-93f1-4778-af4e-1ca1ee6be804",
+Cell[58548, 1598, 276, 5, 23, "ExampleText",ExpressionUUID->"4f95c364-93f1-4778-af4e-1ca1ee6be804",
  CellID->654805157],
 Cell[CellGroupData[{
-Cell[58746, 1605, 1986, 48, 165, "Input",ExpressionUUID->"c74efb92-0269-794b-af7f-4b6829c7bb10",
+Cell[58849, 1607, 1986, 48, 165, "Input",ExpressionUUID->"c74efb92-0269-794b-af7f-4b6829c7bb10",
  CellID->671148953],
-Cell[60735, 1655, 4813, 129, 106, "Output",ExpressionUUID->"de8807a4-9d2a-174c-aa27-d4b4aaeae312",
+Cell[60838, 1657, 4813, 129, 106, "Output",ExpressionUUID->"de8807a4-9d2a-174c-aa27-d4b4aaeae312",
  CellID->1280785804]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[65597, 1790, 718, 13, 23, "ExampleSubsection",ExpressionUUID->"70c5f4f4-489a-465c-a365-a3a6bb3afe2d",
+Cell[65700, 1792, 718, 13, 23, "ExampleSubsection",ExpressionUUID->"70c5f4f4-489a-465c-a365-a3a6bb3afe2d",
  CellID->1036996805],
-Cell[66318, 1805, 411, 10, 23, "ExampleText",ExpressionUUID->"041cec4a-5956-4da6-8304-a081527c2538",
+Cell[66421, 1807, 411, 10, 23, "ExampleText",ExpressionUUID->"041cec4a-5956-4da6-8304-a081527c2538",
  CellID->1975506230],
 Cell[CellGroupData[{
-Cell[66754, 1819, 865, 19, 60, "Input",ExpressionUUID->"f384a361-0a20-4bcc-ac15-506b4cbc0d3b",
+Cell[66857, 1821, 865, 19, 60, "Input",ExpressionUUID->"f384a361-0a20-4bcc-ac15-506b4cbc0d3b",
  CellID->88541343],
-Cell[67622, 1840, 10683, 224, 50, "Output",ExpressionUUID->"3e6cc0ba-a89f-431d-8426-c1b7e5ad5225",
+Cell[67725, 1842, 10683, 224, 50, "Output",ExpressionUUID->"3e6cc0ba-a89f-431d-8426-c1b7e5ad5225",
  CellID->254211235]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
-Cell[78344, 2069, 248, 5, 32, "ExampleSection",ExpressionUUID->"0d54ec61-ab7c-4802-a22b-16908247134f",
+Cell[78447, 2071, 248, 5, 32, "ExampleSection",ExpressionUUID->"0d54ec61-ab7c-4802-a22b-16908247134f",
  CellID->466091341],
 Cell[CellGroupData[{
-Cell[78617, 2078, 258, 5, 20, "ExampleSection",ExpressionUUID->"ae535a9b-e8d7-4579-92e7-f72773096d65",
+Cell[78720, 2080, 258, 5, 20, "ExampleSection",ExpressionUUID->"ae535a9b-e8d7-4579-92e7-f72773096d65",
  CellID->113613961],
 Cell[CellGroupData[{
-Cell[78900, 2087, 767, 14, 23, "ExampleSubsection",ExpressionUUID->"7e375bee-9264-784e-8fc9-b01785875e8b",
+Cell[79003, 2089, 767, 14, 23, "ExampleSubsection",ExpressionUUID->"7e375bee-9264-784e-8fc9-b01785875e8b",
  CellID->296669070],
-Cell[79670, 2103, 1472, 25, 55, "ExampleText",ExpressionUUID->"d0fa4c32-017f-6941-9e2b-bed568d07987",
+Cell[79773, 2105, 1472, 25, 55, "ExampleText",ExpressionUUID->"d0fa4c32-017f-6941-9e2b-bed568d07987",
  CellID->105689035],
-Cell[81145, 2130, 1559, 26, 39, "ExampleText",ExpressionUUID->"de31d0fe-301c-a442-b6c2-0da829655420",
+Cell[81248, 2132, 1559, 26, 39, "ExampleText",ExpressionUUID->"de31d0fe-301c-a442-b6c2-0da829655420",
  CellID->709734105],
-Cell[82707, 2158, 1444, 28, 71, "ExampleText",ExpressionUUID->"efc5cb6f-fc63-7e4a-a77b-e01c3c1ceac3",
+Cell[82810, 2160, 1444, 28, 71, "ExampleText",ExpressionUUID->"efc5cb6f-fc63-7e4a-a77b-e01c3c1ceac3",
  CellID->105347582],
 Cell[CellGroupData[{
-Cell[84176, 2190, 2336, 52, 158, "Input",ExpressionUUID->"afc51794-de33-a843-84c0-d8eb813a2698",
+Cell[84279, 2192, 2336, 52, 158, "Input",ExpressionUUID->"afc51794-de33-a843-84c0-d8eb813a2698",
  CellID->448289478],
-Cell[86515, 2244, 3207, 80, 47, "Output",ExpressionUUID->"6f65396e-fec0-b440-ac40-9c94c63f6915",
+Cell[86618, 2246, 3207, 80, 47, "Output",ExpressionUUID->"6f65396e-fec0-b440-ac40-9c94c63f6915",
  CellID->1351737]
 }, Open  ]],
-Cell[89737, 2327, 1012, 15, 55, "ExampleText",ExpressionUUID->"d0b215a8-271e-7748-8dce-b5f2ca7ba53d",
+Cell[89840, 2329, 1012, 15, 55, "ExampleText",ExpressionUUID->"d0b215a8-271e-7748-8dce-b5f2ca7ba53d",
  CellID->135010306],
-Cell[90752, 2344, 1301, 20, 55, "ExampleText",ExpressionUUID->"5e0470fd-1dee-c445-84c1-352ca10dd65d",
+Cell[90855, 2346, 1301, 20, 55, "ExampleText",ExpressionUUID->"5e0470fd-1dee-c445-84c1-352ca10dd65d",
  CellID->359104851]
 }, Open  ]]
 }, Open  ]],
-Cell[92080, 2368, 251, 5, 32, "ExampleSection",ExpressionUUID->"0eceeb89-7d50-4592-9afe-7c312252d0fb",
+Cell[92183, 2370, 251, 5, 32, "ExampleSection",ExpressionUUID->"0eceeb89-7d50-4592-9afe-7c312252d0fb",
  CellID->594336563],
-Cell[92334, 2375, 256, 5, 20, "ExampleSection",ExpressionUUID->"3232c9e5-853c-43cf-a0c3-cece249b6374",
+Cell[92437, 2377, 256, 5, 20, "ExampleSection",ExpressionUUID->"3232c9e5-853c-43cf-a0c3-cece249b6374",
  CellID->763924802],
-Cell[92593, 2382, 248, 5, 20, "ExampleSection",ExpressionUUID->"335741ac-c3bf-4f98-b769-2a015f5bbb0e",
+Cell[92696, 2384, 248, 5, 20, "ExampleSection",ExpressionUUID->"335741ac-c3bf-4f98-b769-2a015f5bbb0e",
  CellID->76990128]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[92878, 2392, 109, 1, 71, "MetadataSection",ExpressionUUID->"04cac98b-4434-4558-bb5c-a50bffbaf3c6",
+Cell[92981, 2394, 109, 1, 71, "MetadataSection",ExpressionUUID->"04cac98b-4434-4558-bb5c-a50bffbaf3c6",
  CellID->42901253],
-Cell[92990, 2395, 473, 12, 26, "History",ExpressionUUID->"a9449086-5e97-4202-a957-8ef347936728",
+Cell[93093, 2397, 473, 12, 26, "History",ExpressionUUID->"a9449086-5e97-4202-a957-8ef347936728",
  CellID->969934],
 Cell[CellGroupData[{
-Cell[93488, 2411, 484, 13, 21, "CategorizationSection",ExpressionUUID->"df9aef4c-2850-49c2-a631-981bc53613de",
+Cell[93591, 2413, 484, 13, 21, "CategorizationSection",ExpressionUUID->"df9aef4c-2850-49c2-a631-981bc53613de",
  CellID->155892578],
-Cell[93975, 2426, 134, 2, 35, "Categorization",ExpressionUUID->"37577286-8a2e-4690-95d1-258cd136aac3",
+Cell[94078, 2428, 134, 2, 35, "Categorization",ExpressionUUID->"37577286-8a2e-4690-95d1-258cd136aac3",
  CellID->379313778],
-Cell[94112, 2430, 159, 2, 35, "Categorization",ExpressionUUID->"15fdabe5-69c0-4859-8ec5-136948b0dc35",
+Cell[94215, 2432, 159, 2, 35, "Categorization",ExpressionUUID->"15fdabe5-69c0-4859-8ec5-136948b0dc35",
  CellID->123752965],
-Cell[94274, 2434, 156, 2, 35, "Categorization",ExpressionUUID->"c4965993-9dd5-4758-bf37-c7cd4d83d488",
+Cell[94377, 2436, 156, 2, 35, "Categorization",ExpressionUUID->"c4965993-9dd5-4758-bf37-c7cd4d83d488",
  CellID->207073079],
-Cell[94433, 2438, 277, 6, 35, "Categorization",ExpressionUUID->"bb49b832-e02e-40af-9542-ed5332d2229c",
+Cell[94536, 2440, 277, 6, 35, "Categorization",ExpressionUUID->"bb49b832-e02e-40af-9542-ed5332d2229c",
  CellID->485781109]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[94747, 2449, 109, 1, 31, "KeywordsSection",ExpressionUUID->"b9218ebb-8180-446d-816f-0ae498757f49",
+Cell[94850, 2451, 109, 1, 31, "KeywordsSection",ExpressionUUID->"b9218ebb-8180-446d-816f-0ae498757f49",
  CellID->55111812],
-Cell[94859, 2452, 98, 1, 21, "Keywords",ExpressionUUID->"ef98b38b-9a15-4564-a72a-1ac60a848bb4",
+Cell[94962, 2454, 98, 1, 21, "Keywords",ExpressionUUID->"ef98b38b-9a15-4564-a72a-1ac60a848bb4",
  CellID->78694749]
 }, Closed]],
 Cell[CellGroupData[{
-Cell[94994, 2458, 119, 1, 21, "TemplatesSection",ExpressionUUID->"fc1f065b-1492-425c-99fa-0fbdcd783aa2",
+Cell[95097, 2460, 119, 1, 21, "TemplatesSection",ExpressionUUID->"fc1f065b-1492-425c-99fa-0fbdcd783aa2",
  CellID->272215535],
-Cell[95116, 2461, 148, 2, 29, "Template",ExpressionUUID->"78c4c51d-f3aa-458d-8e24-a157e274b180",
+Cell[95219, 2463, 148, 2, 29, "Template",ExpressionUUID->"78c4c51d-f3aa-458d-8e24-a157e274b180",
  CellID->476199561],
-Cell[95267, 2465, 136, 2, 29, "Template",ExpressionUUID->"b58c10d5-6253-4796-b2f6-1caf21f791fc",
+Cell[95370, 2467, 136, 2, 29, "Template",ExpressionUUID->"b58c10d5-6253-4796-b2f6-1caf21f791fc",
  CellID->39443153],
-Cell[95406, 2469, 135, 2, 29, "Template",ExpressionUUID->"ebf094e1-882d-4d8c-804a-0d7e4eed420a",
+Cell[95509, 2471, 135, 2, 29, "Template",ExpressionUUID->"ebf094e1-882d-4d8c-804a-0d7e4eed420a",
  CellID->140411135],
-Cell[95544, 2473, 135, 2, 29, "Template",ExpressionUUID->"6d40d3de-5ebb-47e0-bd08-01bdad3c6d3a",
+Cell[95647, 2475, 135, 2, 29, "Template",ExpressionUUID->"6d40d3de-5ebb-47e0-bd08-01bdad3c6d3a",
  CellID->8216975]
 }, Closed]]
 }, Open  ]]

--- a/Paclet/Documentation/English/ReferencePages/Symbols/NonReciprocalTBHamiltonian.nb
+++ b/Paclet/Documentation/English/ReferencePages/Symbols/NonReciprocalTBHamiltonian.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[    162862,       3854]
-NotebookOptionsPosition[    145528,       3495]
-NotebookOutlinePosition[    146307,       3520]
-CellTagsIndexPosition[    146226,       3515]
+NotebookDataLength[    185448,       4359]
+NotebookOptionsPosition[    166268,       3968]
+NotebookOutlinePosition[    167053,       3993]
+CellTagsIndexPosition[    166972,       3988]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -306,6 +306,109 @@ edge or a number if ",
  CellID->122405462,ExpressionUUID->"916d2e20-f426-4271-9d7c-a98609af83a2"],
 
 Cell[TextData[{
+ "For multi-orbital models with ",
+ Cell[BoxData[
+  StyleBox["norb", "TI"]], "InlineFormula",ExpressionUUID->
+  "213aa462-443a-5947-b599-20d5c8d9ade2"],
+ "\[NotEqual]",
+ StyleBox["1", "InlineCode"],
+ ", the specification of the hopping matrix for the hopping amplitudes  ",
+ Cell[BoxData[
+  StyleBox["hoppingsOpposite", "TI"]], "InlineFormula",ExpressionUUID->
+  "e1146ad2-589b-b54f-9880-e912d3a711af"],
+ " need to follow the same assignment conventions as the hopping amplitudes \
+",
+ Cell[BoxData[
+  StyleBox["hoppingsCanonical", "TI"]], "InlineFormula",ExpressionUUID->
+  "34a82d16-daa7-9d4d-9517-77c7d6e13191"],
+ ". In order to illustrate the used convention it is instructive to consider \
+a general two-orbital ",
+ StyleBox["{p,q}", "InlineCode"],
+ "-lattice model with nearest-neighbor interactions on an arbitrary unit cell \
+with two sites specified on a finite flake. Consider the two sites ",
+ StyleBox["i", "InlineCode"],
+ " and ",
+ StyleBox["j", "InlineCode"],
+ " in a unit cell, each equipped with two orbitals ",
+ StyleBox["a", "InlineCode"],
+ " and ",
+ StyleBox["b", "InlineCode"],
+ ". Further, let a hopping in the canonical direction be defined as ",
+ StyleBox["i", "InlineCode"],
+ " \[Rule] ",
+ StyleBox["j,", "InlineCode"],
+ " and ",
+ StyleBox["j", "InlineCode"],
+ " \[Rule] ",
+ StyleBox["i", "InlineCode"],
+ " in the opposite direction. The following hopping matrices need to be \
+specified, where each matrix entry specifies the corresponding hopping \
+amplitudes between corresponding pairs of orbitals:"
+}], "Notes",
+ CellChangeTimes->{{3.959416241755583*^9, 3.959416242459528*^9}, {
+   3.9594167264317684`*^9, 3.959416768108032*^9}, {3.959417246453047*^9, 
+   3.9594172834939194`*^9}, 3.9594174076191235`*^9, {3.9594180058355064`*^9, 
+   3.9594180491644745`*^9}, {3.9594184160936623`*^9, 3.959418652769972*^9}, {
+   3.9594186847437496`*^9, 3.9594187085016575`*^9}, {3.9594187469976215`*^9, 
+   3.959418815211241*^9}, {3.959419067188925*^9, 3.959419090362995*^9}, {
+   3.9594205426341953`*^9, 3.9594205767974167`*^9}, {3.9594238782360744`*^9, 
+   3.9594239039424057`*^9}},
+ CellID->311370265,ExpressionUUID->"9e832cf1-cb3b-944b-87d7-d59ba8c6c42e"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{
+   RowBox[{"hoppingsCanonical", "=", 
+    RowBox[{
+     RowBox[{"(", GridBox[{
+        {
+         RowBox[{
+          SubscriptBox["a", "i"], "\[Rule]", 
+          SubscriptBox["a", "j"]}], 
+         RowBox[{
+          SubscriptBox["a", "i"], "\[Rule]", 
+          SubscriptBox["b", "j"]}]},
+        {
+         RowBox[{
+          SubscriptBox["b", "i"], "\[Rule]", 
+          SubscriptBox["b", "j"]}], 
+         RowBox[{
+          SubscriptBox["b", "i"], "\[Rule]", 
+          SubscriptBox["b", "j"]}]}
+       }], ")"}], "&"}]}], ";"}], " "}]], "Notes",
+ CellChangeTimes->{{3.9594190921442356`*^9, 3.9594191869209785`*^9}, {
+   3.9594199305607395`*^9, 3.959419942131056*^9}, 3.9594199844307747`*^9, {
+   3.959420111086876*^9, 3.9594201114812164`*^9}, 3.959420152732893*^9},
+ CellID->207376718,ExpressionUUID->"9d096777-ed38-fa42-a3f0-204ba6b6a912"],
+
+Cell[TextData[Cell[BoxData[
+ RowBox[{
+  RowBox[{"hoppingsOpposite", "=", 
+   RowBox[{
+    RowBox[{"(", GridBox[{
+       {
+        RowBox[{
+         SubscriptBox["a", "i"], "\[LeftArrow]", 
+         SubscriptBox["a", "j"]}], 
+        RowBox[{
+         SubscriptBox["a", "i"], "\[LeftArrow]", 
+         SubscriptBox["b", "j"]}]},
+       {
+        RowBox[{
+         SubscriptBox["b", "i"], "\[LeftArrow]", 
+         SubscriptBox["b", "j"]}], 
+        RowBox[{
+         SubscriptBox["b", "i"], "\[LeftArrow]", 
+         SubscriptBox["b", "j"]}]}
+      }], ")"}], "&"}]}], ";"}]],
+ CellChangeTimes->{{3.9594190921442356`*^9, 3.9594191869209785`*^9}, {
+  3.9594199305607395`*^9, 
+  3.959419942131056*^9}},ExpressionUUID->"6a2b9153-008e-0c44-bc72-\
+a9eec9fdfb31"]], "Notes",
+ CellChangeTimes->{{3.959420522251034*^9, 3.9594205393492985`*^9}},
+ CellID->396819643,ExpressionUUID->"ad6e1f75-94fc-a24f-8210-98a92e4ba89d"],
+
+Cell[TextData[{
  "The number of orbitals is specified by ",
  Cell[BoxData[
   StyleBox["norb", "TI"]], "InlineFormula",ExpressionUUID->
@@ -473,6 +576,130 @@ edge or a number if ",
   3.9374212062405586`*^9, 3.9374212234978085`*^9}, {3.937649883978386*^9, 
   3.937649883978386*^9}},
  CellID->978527526,ExpressionUUID->"befd335a-f1a3-a742-adb8-bd6148e17917"],
+
+Cell[TextData[{
+ "For multi-orbital models with ",
+ Cell[BoxData[
+  StyleBox["norb", "TI"]], "InlineFormula",ExpressionUUID->
+  "b470e289-fa16-4a40-9a15-94316920b6bb"],
+ "\[NotEqual]",
+ StyleBox["1", "InlineCode"],
+ ", the specification of the hopping matrix for the hopping amplitudes  ",
+ Cell[BoxData[
+  StyleBox["hoppingsOppositePC", "TI"]], "InlineFormula",ExpressionUUID->
+  "a266a95f-4ba8-4a4c-a3bb-2a9d821ddcee"],
+ " need to follow the same assignment conventions as the hopping amplitudes \
+",
+ Cell[BoxData[
+  StyleBox["hoppingsCanonicalPC", "TI"]], "InlineFormula",ExpressionUUID->
+  "88b9d73c-ea06-f84a-91f5-e47814cebca1"],
+ ". In order to illustrate the used convention it is instructive to consider \
+a general two-orbital ",
+ StyleBox["{p,q}", "InlineCode"],
+ "-lattice model with nearest-neighbor interactions on an arbitrary unit cell \
+with two sites specified on a finite flake with a disclination defect . \
+Consider the two sites ",
+ StyleBox["i", "InlineCode"],
+ " and ",
+ StyleBox["j", "InlineCode"],
+ " in a unit cell, each equipped with two orbitals ",
+ StyleBox["a", "InlineCode"],
+ " and ",
+ StyleBox["b", "InlineCode"],
+ ". Further, let a hopping in the canonical direction be defined as ",
+ StyleBox["i", "InlineCode"],
+ " \[Rule] ",
+ StyleBox["j,", "InlineCode"],
+ " and ",
+ StyleBox["j", "InlineCode"],
+ " \[Rule] ",
+ StyleBox["i", "InlineCode"],
+ " in the opposite direction. The following hopping matrices need to be \
+specified, where each matrix entry specifies the corresponding hopping \
+amplitudes between corresponding pairs of orbitals:"
+}], "Notes",
+ CellChangeTimes->{{3.959416241755583*^9, 3.959416242459528*^9}, {
+   3.9594167264317684`*^9, 3.959416768108032*^9}, {3.959417246453047*^9, 
+   3.9594172834939194`*^9}, 3.9594174076191235`*^9, {3.9594180058355064`*^9, 
+   3.9594180491644745`*^9}, {3.9594184160936623`*^9, 3.959418652769972*^9}, {
+   3.9594186847437496`*^9, 3.9594187085016575`*^9}, {3.9594187469976215`*^9, 
+   3.959418815211241*^9}, {3.959419067188925*^9, 3.959419090362995*^9}, {
+   3.9594205426341953`*^9, 3.9594205767974167`*^9}, {3.9594209013972054`*^9, 
+   3.959420903402071*^9}, {3.9594226849460506`*^9, 3.9594227710742455`*^9}, 
+   3.959422825591652*^9, {3.9594238517981815`*^9, 3.959423864861786*^9}, {
+   3.9594239176290054`*^9, 3.959423937512869*^9}},
+ CellID->49378578,ExpressionUUID->"14065189-ed9c-344a-85a6-123ab8a4107c"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{
+   RowBox[{"hoppingsCanonicalPC", "=", 
+    RowBox[{
+     RowBox[{"(", GridBox[{
+        {
+         RowBox[{
+          SubscriptBox["a", "i"], "\[Rule]", 
+          SubscriptBox["a", "j"]}], 
+         RowBox[{
+          SubscriptBox["a", "i"], "\[Rule]", 
+          SubscriptBox["b", "j"]}]},
+        {
+         RowBox[{
+          SubscriptBox["b", "i"], "\[Rule]", 
+          SubscriptBox["b", "j"]}], 
+         RowBox[{
+          SubscriptBox["b", "i"], "\[Rule]", 
+          SubscriptBox["b", "j"]}]}
+       }], ")"}], "&"}]}], ";"}], " "}]], "Notes",
+ CellChangeTimes->{{3.9594190921442356`*^9, 3.9594191869209785`*^9}, {
+   3.9594199305607395`*^9, 3.959419942131056*^9}, 3.9594199844307747`*^9, {
+   3.959420111086876*^9, 3.9594201114812164`*^9}, 3.959420152732893*^9, {
+   3.9594227010783463`*^9, 3.959422701282736*^9}},
+ CellID->367081081,ExpressionUUID->"c8bb76f0-24c8-404a-81f9-e75585047e2e"],
+
+Cell[TextData[Cell[BoxData[
+ RowBox[{
+  RowBox[{"hoppingsOppositePC", "=", 
+   RowBox[{
+    RowBox[{"(", GridBox[{
+       {
+        RowBox[{
+         SubscriptBox["a", "i"], "\[LeftArrow]", 
+         SubscriptBox["a", "j"]}], 
+        RowBox[{
+         SubscriptBox["a", "i"], "\[LeftArrow]", 
+         SubscriptBox["b", "j"]}]},
+       {
+        RowBox[{
+         SubscriptBox["b", "i"], "\[LeftArrow]", 
+         SubscriptBox["b", "j"]}], 
+        RowBox[{
+         SubscriptBox["b", "i"], "\[LeftArrow]", 
+         SubscriptBox["b", "j"]}]}
+      }], ")"}], "&"}]}], ";"}]],
+ CellChangeTimes->{{3.9594190921442356`*^9, 3.9594191869209785`*^9}, {
+  3.9594199305607395`*^9, 
+  3.959419942131056*^9}},ExpressionUUID->"51d8c5b4-430c-7c43-bcd8-\
+672281462a54"]], "Notes",
+ CellChangeTimes->{{3.959420522251034*^9, 3.9594205393492985`*^9}, {
+  3.9594227034669304`*^9, 3.959422703616144*^9}},
+ CellID->285432429,ExpressionUUID->"8d2c174b-0d89-2f4d-93e6-d4ab5843940d"],
+
+Cell[TextData[{
+ "Analogously, the specification of the hopping matrix for the hopping \
+amplitudes  ",
+ Cell[BoxData[
+  StyleBox["hoppingsOppositeGluedEdges", "TI"]], "InlineFormula",
+  ExpressionUUID->"12d4fa68-7c28-0f4d-8ff1-b13b09c92bc9"],
+ " need to follow the same assignment conventions as the hopping amplitudes \
+",
+ Cell[BoxData[
+  StyleBox["hoppingsCanonicalGluedEdges", "TI"]], "InlineFormula",
+  ExpressionUUID->"e4c82509-1a14-2d40-b022-d7d1d127ded1"],
+ ". "
+}], "Notes",
+ CellChangeTimes->{3.959423810068676*^9},
+ CellID->602129332,ExpressionUUID->"d173a5c5-bc1e-3d47-a90c-5521c018062a"],
 
 Cell["The following options can be given:", "Notes",
  CellChangeTimes->{{3.906026854624065*^9, 3.9060268604382353`*^9}, 
@@ -680,10 +907,10 @@ NonReciprocalAbelianBlochHamiltonian"]], "InlineSeeAlsoFunction",
     "429010f2-dc11-0d47-84f1-dce239246c39"], 
    DynamicModuleBox[{$CellContext`nbobj$$ = NotebookObject[
     "ca524783-33ba-4436-a7c7-e9b68abdb844", 
-     "1bc8fdf5-a8a3-e54e-9079-2074d1741c9a"], $CellContext`cellobj$$ = 
+     "fa97ef78-ffa8-c645-8af3-c151b65e2622"], $CellContext`cellobj$$ = 
     CellObject[
     "33b21f5c-9fe9-244c-ae30-addab55a5b8a", 
-     "c428abb0-4df0-4c4d-99ba-bd2d4b351c5c"]}, 
+     "0f82979c-74b3-324a-95ed-8e25a3306ae7"]}, 
     TemplateBox[{
       GraphicsBox[{{
          Thickness[0.06], 
@@ -3198,7 +3425,7 @@ Cell[BoxData[
 
 Cell[TextData[{
  "Non-reciprocal tight-binding Hamiltonians are generalizations of \
-tight-binding Hamiltonians, which can be constructed with the function  ",
+tight-binding Hamiltonians, the latter can be constructed with the function  ",
  Cell[BoxData[
   ButtonBox["TBHamiltonian",
    BaseStyle->"Link",
@@ -3220,7 +3447,8 @@ analogously. Crucially, the following convention is imposed:"
    3.955170301413376*^9, 3.955170391316994*^9}, {3.955170445563442*^9, 
    3.9551705987731857`*^9}, {3.955176636663025*^9, 3.955176641047663*^9}, {
    3.9551768148026085`*^9, 3.9551768275227795`*^9}, {3.955176863612985*^9, 
-   3.955176863612985*^9}, {3.9551786603626556`*^9, 3.9551787363078537`*^9}},
+   3.955176863612985*^9}, {3.9551786603626556`*^9, 3.9551787363078537`*^9}, {
+   3.959424368784218*^9, 3.959424372728924*^9}},
  CellID->105689035,ExpressionUUID->"7fae03ca-b5ec-1445-82d3-872a8360a200"],
 
 Cell[TextData[{
@@ -3259,7 +3487,7 @@ model defined on an ",
    BaseStyle->"Link",
    ButtonData->"paclet:PatrickMLenggenhager/HyperBloch/ref/HCModelGraph"]], 
   "InlineFormula",ExpressionUUID->"dce7542b-9b3a-de46-920c-19d9a2c1cc9e"],
- " (here the primitive cell of the {8,8} tessellation) with hopping \
+ " (here the primitive cell of the {8,3} tessellation) with hopping \
 amplitudes ",
  Cell[BoxData[
   StyleBox["hoppingsCanonical", "TI"]], "InlineFormula",ExpressionUUID->
@@ -3278,7 +3506,7 @@ arguments, is:"
    3.9551673567773075`*^9, 3.955167361081892*^9}, {3.955169884838175*^9, 
    3.955169900892893*^9}, {3.9551712636836224`*^9, 3.9551712747634583`*^9}, {
    3.9551714818336887`*^9, 3.9551715032236137`*^9}, {3.955172112773716*^9, 
-   3.955172113753664*^9}},
+   3.955172113753664*^9}, {3.9594266415751133`*^9, 3.959426641738249*^9}},
  CellID->105347582,ExpressionUUID->"e1347469-3698-e04d-b3cd-80a0661f52d5"],
 
 Cell[BoxData[{
@@ -3362,7 +3590,7 @@ Cell[TextData[{
  Cell[BoxData[
   StyleBox["hoppingsOpposite", "TI"]], "InlineFormula",ExpressionUUID->
   "0529fa61-edcd-4442-bb4b-dd3e7bc86909"],
- " it is instructive to think of constructing an Abelian Bloch Hamiltonian \
+ " it is instructive to think of constructing a tight-binding Hamiltonian \
 with adjusted hopping amplitudes. The location of the matrix entries, \
 signifying which orbitals are couped, are not to be adjusted."
 }], "ExampleText",
@@ -3376,8 +3604,253 @@ signifying which orbitals are couped, are not to be adjusted."
    3.955171787968336*^9}, {3.9551718215979214`*^9, 3.955171921880068*^9}, {
    3.955171980553753*^9, 3.95517204996364*^9}, {3.9551721380934505`*^9, 
    3.955172210473549*^9}, {3.955172312600815*^9, 3.95517231343186*^9}, {
-   3.955172798924677*^9, 3.9551728555947685`*^9}},
- CellID->359104851,ExpressionUUID->"e541d214-04a7-bb47-af31-cfed6716a9fe"]
+   3.955172798924677*^9, 3.9551728555947685`*^9}, {3.959427046547167*^9, 
+   3.959427052733345*^9}},
+ CellID->359104851,ExpressionUUID->"e541d214-04a7-bb47-af31-cfed6716a9fe"],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ InterpretationBox[Cell[
+  "\t", "ExampleDelimiter",ExpressionUUID->
+   "a9fd649d-8453-8548-b449-cf1ed38bc9a1"],
+  $Line = 0; Null]], "ExampleDelimiter",
+ CellID->41691713,ExpressionUUID->"90e3572b-3bc2-954e-acdf-2c2209c4376d"],
+
+Cell[TextData[{
+ "Analogously, for disclination (supercell) model graphs the non-reciprocal \
+tight-binding Hamiltonians are generalizations of tight-binding Hamiltonians, \
+the latter can be constructed with the function  ",
+ Cell[BoxData[
+  ButtonBox["TBHamiltonian",
+   BaseStyle->"Link",
+   ButtonData->"paclet:PatrickMLenggenhager/HyperBloch/ref/TBHamiltonian"]], 
+  "InlineFormula",ExpressionUUID->"9bf61ad6-ad50-5944-bcca-17da799ae99c"],
+ ". As such, the onsite potential and the hopping amplitudes are specified \
+analogously. Crucially, the following convention is imposed:"
+}], "ExampleText",
+ CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
+   3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
+   3.906028831115154*^9}, {3.906028997135098*^9, 3.906029000923377*^9}, 
+   3.9345103390559063`*^9, {3.937421005016327*^9, 3.9374210159177094`*^9}, {
+   3.955167356777308*^9, 3.955167361081892*^9}, {3.955168934862646*^9, 
+   3.955168998679025*^9}, {3.9551691386825943`*^9, 3.955169194672315*^9}, {
+   3.955169256152302*^9, 3.955169493182674*^9}, {3.955169586572748*^9, 
+   3.955169712677645*^9}, {3.955169791552847*^9, 3.9551697986726894`*^9}, {
+   3.955169850973112*^9, 3.9551698519929743`*^9}, {3.955169927112825*^9, 
+   3.955170211827799*^9}, {3.955170242038122*^9, 3.955170255833084*^9}, {
+   3.955170301413376*^9, 3.955170391316994*^9}, {3.955170445563442*^9, 
+   3.9551705987731857`*^9}, {3.955176636663025*^9, 3.955176641047663*^9}, {
+   3.9551768148026085`*^9, 3.9551768275227795`*^9}, {3.955176863612985*^9, 
+   3.955176863612985*^9}, {3.9551786603626556`*^9, 3.9551787363078537`*^9}, {
+   3.959424377039385*^9, 3.9594243848944225`*^9}, {3.959426485016968*^9, 
+   3.9594265234404755`*^9}, {3.9594267259613895`*^9, 
+   3.9594267550906963`*^9}, {3.959426819278822*^9, 3.9594268987840557`*^9}},
+ CellID->626781485,ExpressionUUID->"7879bff2-3886-2a43-9c05-3019887669c4"],
+
+Cell[TextData[{
+ "To specify the hopping matrix for the hopping amplitudes  ",
+ Cell[BoxData[
+  StyleBox["hoppingsOppositePC", "TI"]], "InlineFormula",ExpressionUUID->
+  "d13d3e1b-e33b-de45-afd6-3421b263fb04"],
+ " and  ",
+ Cell[BoxData[
+  StyleBox["hoppingsOppositeGluedEdges", "TI"]], "InlineFormula",
+  ExpressionUUID->"c9c2a46c-7fbc-814a-9b2a-26febbd3517b"],
+ " appropriately, the positions of the matrix entries for each pair of \
+orbitals is inherited from the hopping matrix ",
+ Cell[BoxData[
+  StyleBox["hoppingsCanonicalPC", "TI"]], "InlineFormula",ExpressionUUID->
+  "29a80d30-2910-1a47-b76c-7b96e4e3d09d"],
+ " and ",
+ Cell[BoxData[
+  StyleBox["hoppingsCanonicalGluedEdges", "TI"]], "InlineFormula",
+  ExpressionUUID->"7e327143-01ee-f541-9dec-a16d889cc8e9"],
+ ", respectively. "
+}], "ExampleText",
+ CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
+   3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
+   3.906028831115154*^9}, {3.906028997135098*^9, 3.906029000923377*^9}, 
+   3.9345103390559063`*^9, {3.937421005016327*^9, 3.9374210159177094`*^9}, {
+   3.955167356777308*^9, 3.955167361081892*^9}, {3.955168934862646*^9, 
+   3.955168998679025*^9}, {3.9551691386825943`*^9, 3.955169194672315*^9}, {
+   3.955169256152302*^9, 3.955169493182674*^9}, {3.955169586572748*^9, 
+   3.955169712677645*^9}, {3.955169791552847*^9, 3.9551697986726894`*^9}, {
+   3.955169850973112*^9, 3.9551698519929743`*^9}, {3.955169927112825*^9, 
+   3.955170211827799*^9}, {3.955170242038122*^9, 3.955170255833084*^9}, {
+   3.955170301413376*^9, 3.955170391316994*^9}, {3.955170445563442*^9, 
+   3.955170745103998*^9}, {3.95517080197999*^9, 3.955170813024542*^9}, {
+   3.955171255916292*^9, 3.9551712615131607`*^9}, {3.955172093403908*^9, 
+   3.955172093884252*^9}, {3.959426534952677*^9, 3.9594265384228554`*^9}, {
+   3.95942666950428*^9, 3.9594267082484436`*^9}},
+ CellID->21247980,ExpressionUUID->"ddc09895-8ca9-8f42-8593-3dfa322b150c"],
+
+Cell[TextData[{
+ "For example, the non-reciprocal Abelian Bloch Hamiltonian of a hopping \
+model defined on a disclination model graph ",
+ Cell[BoxData[
+  ButtonBox["HBDisclinationModelGraph",
+   BaseStyle->"Link",
+   ButtonData->
+    "paclet:PatrickMLenggenhager/HyperBloch/ref/HBDisclinationModelGraph"]], 
+  "InlineFormula",ExpressionUUID->"6656c5a0-9480-ce4f-9c40-721af532bb51"],
+ " (here the primitive cell of the {8,3} tessellation) with hopping \
+amplitudes ",
+ Cell[BoxData[
+  StyleBox["hoppingsCanonicalPC", "TI"]], "InlineFormula",ExpressionUUID->
+  "1a43166e-3c55-0e40-af6a-34a7a6bcb44c"],
+ " and ",
+ Cell[BoxData[
+  StyleBox["hoppingsCanonicalGluedEdges", "TI"]], "InlineFormula",
+  ExpressionUUID->"c00a3338-4d7d-3745-b1be-3e053277e466"],
+ "in the canonical directions and ",
+ Cell[BoxData[
+  StyleBox["hoppingsOppositePC", "TI"]], "InlineFormula",ExpressionUUID->
+  "c279b144-cbd6-7a43-953c-77e7117c50f5"],
+ " and ",
+ Cell[BoxData[
+  StyleBox["hoppingsOppositeGluedEdges", "TI"]], "InlineFormula",
+  ExpressionUUID->"928a6883-b51e-2c46-8c16-3878b6e55a13"],
+ " in the opposite directions and two orbitals per site, using symbolic \
+arguments, is:"
+}], "ExampleText",
+ CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
+   3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
+   3.906028831115154*^9}, {3.906028997135098*^9, 3.906029000923377*^9}, 
+   3.9345103390559063`*^9, {3.937421005016327*^9, 3.9374210159177094`*^9}, {
+   3.9551673567773075`*^9, 3.955167361081892*^9}, {3.955169884838175*^9, 
+   3.955169900892893*^9}, {3.9551712636836224`*^9, 3.9551712747634583`*^9}, {
+   3.9551714818336887`*^9, 3.9551715032236137`*^9}, {3.955172112773716*^9, 
+   3.955172113753664*^9}, {3.9594265563453846`*^9, 3.959426568140648*^9}, {
+   3.9594266260259113`*^9, 3.959426645749092*^9}, 3.959426740308613*^9, {
+   3.959426914129896*^9, 3.9594269349079227`*^9}},
+ CellID->85481949,ExpressionUUID->"06029ee0-0624-264a-a3b9-4e23ea9b1bda"],
+
+Cell[BoxData[{
+ RowBox[{
+  RowBox[{"originalPCMGraph", " ", "=", " ", 
+   RowBox[{"HCExampleData", "[", "\"\<{8,3}-tess_T2.1_3.hcm\>\"", "]"}]}], 
+  ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"disclinationMG", " ", "=", " ", 
+   RowBox[{"IntroduceDisclination", "[", 
+    RowBox[{"originalPCMGraph", ",", 
+     RowBox[{"-", "1"}], ",", "0"}], "]"}]}], ";"}]}], "Input",
+ CellChangeTimes->{{3.906027063408805*^9, 3.906027088319622*^9}, {
+   3.9060271833899145`*^9, 3.906027223799124*^9}, 3.906028315145218*^9, {
+   3.906028607996865*^9, 3.906028613837571*^9}, {3.9060286781196327`*^9, 
+   3.906028694807095*^9}, {3.906028732857873*^9, 3.906028753463425*^9}, {
+   3.906028853588249*^9, 3.906028970614804*^9}, {3.906029009568014*^9, 
+   3.9060291359216547`*^9}, 3.906435166479804*^9, 3.918641100224955*^9, 
+   3.918641526860538*^9, {3.937387845590758*^9, 3.937387853871342*^9}, 
+   3.9400965384293613`*^9},
+ CellLabel->"In[1]:=",
+ CellID->219430595,ExpressionUUID->"fc0bec1d-c824-994c-8b82-8ed62b5098f8"],
+
+Cell[BoxData[{
+ RowBox[{
+  RowBox[{"onsitePC", "=", 
+   RowBox[{
+    RowBox[{"(", GridBox[{
+       {"0", 
+        RowBox[{"-", "t1"}]},
+       {"t1", "0"}
+      }], ")"}], "&"}]}], ";"}], "\n", 
+ RowBox[{
+  RowBox[{"hoppingsCanonicalPC", "=", 
+   RowBox[{
+    RowBox[{
+     RowBox[{"-", "t2"}], 
+     RowBox[{"(", GridBox[{
+        {"0", "1"},
+        {"1", "0"}
+       }], ")"}]}], "&"}]}], ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"hoppingsOppositePC", "=", 
+   RowBox[{
+    RowBox[{"t2", 
+     RowBox[{"(", GridBox[{
+        {"0", "1"},
+        {"1", "0"}
+       }], ")"}]}], "&"}]}], ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"hoppingsCanonicalGluedEdges", "=", 
+   RowBox[{
+    RowBox[{
+     RowBox[{"-", "t2"}], 
+     RowBox[{"(", GridBox[{
+        {"0", "1"},
+        {"1", "0"}
+       }], ")"}]}], "&"}]}], ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"hoppingsOppositeGluedEdges", "=", 
+   RowBox[{
+    RowBox[{"t2", 
+     RowBox[{"(", GridBox[{
+        {"0", "1"},
+        {"1", "0"}
+       }], ")"}]}], "&"}]}], ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"H", "=", 
+   RowBox[{"NonReciprocalTBHamiltonian", "[", 
+    RowBox[{"disclinationMG", ",", " ", "originalPCMGraph", ",", 
+     RowBox[{"2", "&"}], ",", "onsitePC", ",", "hoppingsCanonicalPC", ",", 
+     " ", "hoppingsOppositePC", ",", "hoppingsCanonicalGluedEdges", ",", " ", 
+     "hoppingsOppositeGluedEdges"}], " ", "]"}]}], ";"}]}], "Input",
+ CellChangeTimes->{{3.937387885381489*^9, 3.937387933914648*^9}, 
+   3.937387979454754*^9, {3.9373880695073414`*^9, 3.9373881611035175`*^9}, 
+   3.9373882202115993`*^9, {3.9374032029562798`*^9, 3.9374032803582344`*^9}, 
+   3.937403320221674*^9, {3.937421281517321*^9, 3.9374213182834396`*^9}, 
+   3.9376486958622084`*^9, 3.940094530281828*^9, {3.9594269784809933`*^9, 
+   3.9594270159423904`*^9}},
+ CellLabel->"In[9]:=",
+ CellID->676015994,ExpressionUUID->"0007b8f0-acb1-e04c-a6a7-76f76156aad4"],
+
+Cell["\<\
+Specifically, we have set the mass terms of the orbitals to zero, the \
+intra-site coupling to -t1 in the canonical direction and t1 in the opposite \
+direction and the inter-site coupling to -t2  in the canonical direction and \
+t2 in the opposite direction.\
+\>", "ExampleText",
+ CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
+   3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
+   3.906028831115154*^9}, {3.906028997135098*^9, 3.906029000923377*^9}, 
+   3.9345103390559063`*^9, {3.937421005016327*^9, 3.9374210159177094`*^9}, {
+   3.9551673567773075`*^9, 3.955167361081892*^9}, {3.955169884838175*^9, 
+   3.955169900892893*^9}, {3.9551712636836224`*^9, 3.9551712747634583`*^9}, {
+   3.9551714818336887`*^9, 3.9551715032236137`*^9}, {3.955172112773716*^9, 
+   3.955172113753664*^9}, {3.955172958744713*^9, 3.9551729998145275`*^9}, {
+   3.9551738888346024`*^9, 3.955174072975092*^9}, {3.955178351427471*^9, 
+   3.955178362197628*^9}},
+ CellID->397014181,ExpressionUUID->"6b99138a-4076-cf45-a631-dc753e98a605"],
+
+Cell[TextData[{
+ "Note, for the specification of the hopping matrix ",
+ Cell[BoxData[
+  StyleBox["hoppingsOppositePC", "TI"]], "InlineFormula",ExpressionUUID->
+  "1532746b-de3b-3d49-85d0-fd8dc17953b7"],
+ " and ",
+ Cell[BoxData[
+  StyleBox["hoppingsOppositeGluedEdges", "TI"]], "InlineFormula",
+  ExpressionUUID->"ccfa2b1a-974f-7a45-8f98-746652f30bb4"],
+ " it is instructive to think of constructing an tight-binding Hamiltonian \
+with adjusted hopping amplitudes. The location of the matrix entries, \
+signifying which orbitals are couped, are not to be adjusted."
+}], "ExampleText",
+ CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
+   3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
+   3.906028831115154*^9}, {3.906028997135098*^9, 3.906029000923377*^9}, 
+   3.9345103390559063`*^9, {3.937421005016327*^9, 3.9374210159177094`*^9}, {
+   3.9551673567773075`*^9, 3.955167361081892*^9}, {3.955169884838175*^9, 
+   3.955169900892893*^9}, {3.9551712636836224`*^9, 3.9551712747634583`*^9}, {
+   3.9551714818336887`*^9, 3.9551715032236137`*^9}, {3.9551715785834274`*^9, 
+   3.955171787968336*^9}, {3.9551718215979214`*^9, 3.955171921880068*^9}, {
+   3.955171980553753*^9, 3.95517204996364*^9}, {3.9551721380934505`*^9, 
+   3.955172210473549*^9}, {3.955172312600815*^9, 3.95517231343186*^9}, {
+   3.955172798924677*^9, 3.9551728555947685`*^9}, 3.959427031232956*^9, {
+   3.959427063103359*^9, 3.9594270660505753`*^9}},
+ CellID->179261880,ExpressionUUID->"c4d37578-6565-334c-b1fa-0d179c17ecf1"]
+}, Open  ]]
 }, Open  ]]
 }, Open  ]],
 
@@ -3494,9 +3967,9 @@ Cell[BoxData[""], "Template",
 }, Open  ]]
 },
 WindowSize->{1269, 647},
-WindowMargins->{{0, Automatic}, {Automatic, 0}},
+WindowMargins->{{-5.5, Automatic}, {Automatic, -5.5}},
 TaggingRules-><|"Paclet" -> "PatrickMLenggenhager/HyperBloch"|>,
-FrontEndVersion->"14.0 for Microsoft Windows (64-bit) (December 12, 2023)",
+FrontEndVersion->"14.2 for Microsoft Windows (64-bit) (December 26, 2024)",
 StyleDefinitions->FrontEnd`FileName[{"Wolfram"}, "FunctionPageStylesExt.nb", 
   CharacterEncoding -> "UTF-8"],
 ExpressionUUID->"ca524783-33ba-4436-a7c7-e9b68abdb844"
@@ -3507,352 +3980,384 @@ ExpressionUUID->"ca524783-33ba-4436-a7c7-e9b68abdb844"
 (*CellTagsOutline
 CellTagsIndex->{
  "ExtendedExamples"->{
-  Cell[80304, 1959, 487, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"ff8d6064-9f88-a74d-a8fa-17fb12f09124",
+  Cell[89198, 2186, 487, 13, 56, "ExtendedExamplesSection",ExpressionUUID->"ff8d6064-9f88-a74d-a8fa-17fb12f09124",
    CellTags->"ExtendedExamples",
    CellID->326378688]}
  }
 *)
 (*CellTagsIndex
 CellTagsIndex->{
- {"ExtendedExamples", 146031, 3508}
+ {"ExtendedExamples", 166777, 3981}
  }
 *)
 (*NotebookFileOutline
 Notebook[{
 Cell[CellGroupData[{
-Cell[580, 22, 263, 3, 74, "ObjectName",ExpressionUUID->"153c8566-b789-49e1-9042-3899900e3b7a",
+Cell[580, 22, 263, 3, 72, "ObjectName",ExpressionUUID->"153c8566-b789-49e1-9042-3899900e3b7a",
  CellID->641622780],
-Cell[846, 27, 7311, 167, 288, "Usage",ExpressionUUID->"5a95bc6d-6279-4563-9d22-a21d53dda161",
+Cell[846, 27, 7311, 167, 275, "Usage",ExpressionUUID->"5a95bc6d-6279-4563-9d22-a21d53dda161",
  CellID->207877341],
-Cell[8160, 196, 1606, 35, 48, "Notes",ExpressionUUID->"51a2fb5a-fade-4a72-bf0c-9242b370fb83",
+Cell[8160, 196, 1606, 35, 46, "Notes",ExpressionUUID->"51a2fb5a-fade-4a72-bf0c-9242b370fb83",
  CellID->140612745],
-Cell[9769, 233, 1482, 33, 48, "Notes",ExpressionUUID->"6b8281bc-12b7-9049-85e4-33f8a90d46bf",
+Cell[9769, 233, 1482, 33, 46, "Notes",ExpressionUUID->"6b8281bc-12b7-9049-85e4-33f8a90d46bf",
  CellID->8242630],
-Cell[11254, 268, 1511, 37, 90, "Notes",ExpressionUUID->"916d2e20-f426-4271-9d7c-a98609af83a2",
+Cell[11254, 268, 1511, 37, 87, "Notes",ExpressionUUID->"916d2e20-f426-4271-9d7c-a98609af83a2",
  CellID->122405462],
-Cell[12768, 307, 1608, 35, 48, "Notes",ExpressionUUID->"61fdac31-46a3-0740-85a1-4f9fb65c236b",
+Cell[12768, 307, 2187, 48, 156, "Notes",ExpressionUUID->"9e832cf1-cb3b-944b-87d7-d59ba8c6c42e",
+ CellID->311370265],
+Cell[14958, 357, 882, 24, 41, "Notes",ExpressionUUID->"9d096777-ed38-fa42-a3f0-204ba6b6a912",
+ CellID->207376718],
+Cell[15843, 383, 910, 25, 41, "Notes",ExpressionUUID->"ad6e1f75-94fc-a24f-8210-98a92e4ba89d",
+ CellID->396819643],
+Cell[16756, 410, 1608, 35, 46, "Notes",ExpressionUUID->"61fdac31-46a3-0740-85a1-4f9fb65c236b",
  CellID->372301786],
-Cell[14379, 344, 1485, 33, 48, "Notes",ExpressionUUID->"29c3eeb1-4bd4-fb41-8a8e-6a5cf6292032",
+Cell[18367, 447, 1485, 33, 46, "Notes",ExpressionUUID->"29c3eeb1-4bd4-fb41-8a8e-6a5cf6292032",
  CellID->96192577],
-Cell[15867, 379, 2213, 50, 90, "Notes",ExpressionUUID->"6ee1f639-78fc-9443-9db0-28a0b4f196ff",
+Cell[19855, 482, 2213, 50, 87, "Notes",ExpressionUUID->"6ee1f639-78fc-9443-9db0-28a0b4f196ff",
  CellID->258865958],
-Cell[18083, 431, 1675, 43, 90, "Notes",ExpressionUUID->"befd335a-f1a3-a742-adb8-bd6148e17917",
+Cell[22071, 534, 1675, 43, 87, "Notes",ExpressionUUID->"befd335a-f1a3-a742-adb8-bd6148e17917",
  CellID->978527526],
-Cell[19761, 476, 223, 3, 27, "Notes",ExpressionUUID->"1c7289b5-700a-c54e-9a07-7e04882eec7b",
+Cell[23749, 579, 2394, 51, 159, "Notes",ExpressionUUID->"14065189-ed9c-344a-85a6-123ab8a4107c",
+ CellID->49378578],
+Cell[26146, 632, 936, 25, 41, "Notes",ExpressionUUID->"c8bb76f0-24c8-404a-81f9-e75585047e2e",
+ CellID->367081081],
+Cell[27085, 659, 963, 26, 41, "Notes",ExpressionUUID->"8d2c174b-0d89-2f4d-93e6-d4ab5843940d",
+ CellID->285432429],
+Cell[28051, 687, 601, 14, 43, "Notes",ExpressionUUID->"d173a5c5-bc1e-3d47-a90c-5521c018062a",
+ CellID->602129332],
+Cell[28655, 703, 223, 3, 26, "Notes",ExpressionUUID->"1c7289b5-700a-c54e-9a07-7e04882eec7b",
  CellID->444168746],
-Cell[19987, 481, 1770, 41, 103, "3ColumnTableMod",ExpressionUUID->"ef297d37-914b-8f42-bbda-f7d0f0fab73c",
+Cell[28881, 708, 1770, 41, 87, "3ColumnTableMod",ExpressionUUID->"ef297d37-914b-8f42-bbda-f7d0f0fab73c",
  CellID->65923218]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[21794, 527, 435, 12, 40, "TechNotesSection",ExpressionUUID->"0fea9c94-dcc9-4460-b773-0032ab8ec549",
+Cell[30688, 754, 435, 12, 39, "TechNotesSection",ExpressionUUID->"0fea9c94-dcc9-4460-b773-0032ab8ec549",
  CellID->995312194],
-Cell[22232, 541, 265, 6, 19, "Tutorials",ExpressionUUID->"1928c8e7-a68c-46a0-8cba-0ffff1419b9e",
+Cell[31126, 768, 265, 6, 17, "Tutorials",ExpressionUUID->"1928c8e7-a68c-46a0-8cba-0ffff1419b9e",
  CellID->151400]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[22534, 552, 472, 13, 39, "RelatedLinksSection",ExpressionUUID->"fecb14cf-25fa-4a0c-9894-8ca8438f0be1",
+Cell[31428, 779, 472, 13, 38, "RelatedLinksSection",ExpressionUUID->"fecb14cf-25fa-4a0c-9894-8ca8438f0be1",
  CellID->202509145],
-Cell[23009, 567, 103, 1, 19, "RelatedLinks",ExpressionUUID->"79cdcc1a-2b16-4dc9-9e2d-fc7a3173b09d",
+Cell[31903, 794, 103, 1, 17, "RelatedLinks",ExpressionUUID->"79cdcc1a-2b16-4dc9-9e2d-fc7a3173b09d",
  CellID->144199850]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[23149, 573, 458, 13, 39, "SeeAlsoSection",ExpressionUUID->"8abec620-8af0-574a-9875-b24068b2beef",
+Cell[32043, 800, 458, 13, 38, "SeeAlsoSection",ExpressionUUID->"8abec620-8af0-574a-9875-b24068b2beef",
  CellID->223461721],
-Cell[23610, 588, 5548, 130, 80, "SeeAlso",ExpressionUUID->"1af84081-07d0-944f-aa97-505b313e997c",
+Cell[32504, 815, 5548, 130, 65, "SeeAlso",ExpressionUUID->"1af84081-07d0-944f-aa97-505b313e997c",
  CellID->381155944]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[29195, 723, 182, 2, 39, "MoreAboutSection",ExpressionUUID->"628c56fb-2a64-454a-afda-0c72e8b98f07",
+Cell[38089, 950, 182, 2, 37, "MoreAboutSection",ExpressionUUID->"628c56fb-2a64-454a-afda-0c72e8b98f07",
  CellID->31221473],
-Cell[29380, 727, 281, 6, 19, "MoreAbout",ExpressionUUID->"f716947c-4c12-47a4-9cff-f2a24ce82555",
+Cell[38274, 954, 281, 6, 17, "MoreAbout",ExpressionUUID->"f716947c-4c12-47a4-9cff-f2a24ce82555",
  CellID->542581366]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[29698, 738, 530, 14, 69, "ExamplesInitializationSection",ExpressionUUID->"d27dce01-6ac7-4a45-a9d6-0701f911e181",
+Cell[38592, 965, 530, 14, 68, "ExamplesInitializationSection",ExpressionUUID->"d27dce01-6ac7-4a45-a9d6-0701f911e181",
  CellID->428868112],
-Cell[30231, 754, 306, 5, 45, "ExampleInitialization",ExpressionUUID->"b9b2fab4-94b0-40ca-9b3a-2f0308baac5d",
+Cell[39125, 981, 306, 5, 45, "ExampleInitialization",ExpressionUUID->"b9b2fab4-94b0-40ca-9b3a-2f0308baac5d",
  CellID->127019986]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[30574, 764, 441, 12, 71, "PrimaryExamplesSection",ExpressionUUID->"898c9691-0437-2b4f-911a-086c5248b0cc",
+Cell[39468, 991, 441, 12, 69, "PrimaryExamplesSection",ExpressionUUID->"898c9691-0437-2b4f-911a-086c5248b0cc",
  CellID->11026314],
-Cell[31018, 778, 1069, 18, 77, "ExampleText",ExpressionUUID->"665d84cd-aea7-8c4c-8c5b-c3de1f16dc2a",
+Cell[39912, 1005, 1069, 18, 71, "ExampleText",ExpressionUUID->"665d84cd-aea7-8c4c-8c5b-c3de1f16dc2a",
  CellID->82755364],
-Cell[32090, 798, 608, 11, 25, "Input",ExpressionUUID->"cb9530ef-450c-3c4d-b5fb-7739129fba2c",
+Cell[40984, 1025, 608, 11, 25, "Input",ExpressionUUID->"cb9530ef-450c-3c4d-b5fb-7739129fba2c",
  CellID->642833953],
 Cell[CellGroupData[{
-Cell[32723, 813, 1393, 24, 25, "Input",ExpressionUUID->"3c2d88fc-16a4-9648-b414-401d7d30c089",
+Cell[41617, 1040, 1393, 24, 25, "Input",ExpressionUUID->"3c2d88fc-16a4-9648-b414-401d7d30c089",
  CellID->2282893],
-Cell[34119, 839, 3235, 70, 255, "Output",ExpressionUUID->"a4b4b6d1-2aa0-5749-aa91-cc41f531783d",
+Cell[43013, 1066, 3235, 70, 253, "Output",ExpressionUUID->"a4b4b6d1-2aa0-5749-aa91-cc41f531783d",
  CellID->359213064]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[37391, 914, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"90e38493-127e-0943-b0dd-5f20d374f747",
+Cell[46285, 1141, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"90e38493-127e-0943-b0dd-5f20d374f747",
  CellID->359821871],
-Cell[37636, 921, 286, 4, 24, "ExampleText",ExpressionUUID->"a56d4d89-8494-2b4c-9574-d6b8fda22be9",
+Cell[46530, 1148, 286, 4, 23, "ExampleText",ExpressionUUID->"a56d4d89-8494-2b4c-9574-d6b8fda22be9",
  CellID->36408547],
-Cell[37925, 927, 608, 11, 25, "Input",ExpressionUUID->"b6ba46d0-ca10-4445-89df-535e94fa446a",
+Cell[46819, 1154, 608, 11, 25, "Input",ExpressionUUID->"b6ba46d0-ca10-4445-89df-535e94fa446a",
  CellID->257600641],
 Cell[CellGroupData[{
-Cell[38558, 942, 1550, 29, 43, "Input",ExpressionUUID->"993568ac-0a3d-794c-b3c4-347fedccbdc2",
+Cell[47452, 1169, 1550, 29, 42, "Input",ExpressionUUID->"993568ac-0a3d-794c-b3c4-347fedccbdc2",
  CellID->5704350],
-Cell[40111, 973, 3261, 70, 255, "Output",ExpressionUUID->"445bfc39-30bf-3b4f-9ef5-c47f2ba08cee",
+Cell[49005, 1200, 3261, 70, 253, "Output",ExpressionUUID->"445bfc39-30bf-3b4f-9ef5-c47f2ba08cee",
  CellID->209734678]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[43421, 1049, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"d23bb43d-de1e-2141-b19a-fcc26220e5cf",
+Cell[52315, 1276, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"d23bb43d-de1e-2141-b19a-fcc26220e5cf",
  CellID->677196106],
-Cell[43666, 1056, 1270, 24, 62, "ExampleText",ExpressionUUID->"b39940f6-caca-c24e-a3cb-f0a92ec870c2",
+Cell[52560, 1283, 1270, 24, 55, "ExampleText",ExpressionUUID->"b39940f6-caca-c24e-a3cb-f0a92ec870c2",
  CellID->680708440],
-Cell[44939, 1082, 789, 14, 25, "Input",ExpressionUUID->"0634963b-2374-784f-895a-fc4179f77fea",
+Cell[53833, 1309, 789, 14, 25, "Input",ExpressionUUID->"0634963b-2374-784f-895a-fc4179f77fea",
  CellID->262417576],
-Cell[45731, 1098, 1268, 32, 78, "Input",ExpressionUUID->"5244972a-cb3b-2042-9daf-508c39bf118d",
+Cell[54625, 1325, 1268, 32, 77, "Input",ExpressionUUID->"5244972a-cb3b-2042-9daf-508c39bf118d",
  CellID->6127746],
-Cell[47002, 1132, 1021, 27, 78, "Input",ExpressionUUID->"7c31dba5-8134-0141-a1bc-a995f856c9f1",
+Cell[55896, 1359, 1021, 27, 77, "Input",ExpressionUUID->"7c31dba5-8134-0141-a1bc-a995f856c9f1",
  CellID->480595079],
 Cell[CellGroupData[{
-Cell[48048, 1163, 762, 18, 61, "Input",ExpressionUUID->"47ccee31-e999-4f4b-89f6-b9be1dab7766",
+Cell[56942, 1390, 762, 18, 60, "Input",ExpressionUUID->"47ccee31-e999-4f4b-89f6-b9be1dab7766",
  CellID->523535151],
-Cell[48813, 1183, 2712, 62, 255, "Output",ExpressionUUID->"158e5697-72c7-b546-b7a5-a4fe8fb1d25f",
+Cell[57707, 1410, 2712, 62, 253, "Output",ExpressionUUID->"158e5697-72c7-b546-b7a5-a4fe8fb1d25f",
  CellID->3419141]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[51574, 1251, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"420659d6-69c7-4b47-91d4-186ffaa4ea80",
+Cell[60468, 1478, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"420659d6-69c7-4b47-91d4-186ffaa4ea80",
  CellID->228953716],
-Cell[51819, 1258, 919, 17, 43, "ExampleText",ExpressionUUID->"73bd323e-2983-3346-a43a-e9815c20bad5",
+Cell[60713, 1485, 919, 17, 39, "ExampleText",ExpressionUUID->"73bd323e-2983-3346-a43a-e9815c20bad5",
  CellID->16699796],
-Cell[52741, 1277, 808, 14, 25, "Input",ExpressionUUID->"2c5d52cb-ae6f-0e45-a6e8-437f9ee96292",
+Cell[61635, 1504, 808, 14, 25, "Input",ExpressionUUID->"2c5d52cb-ae6f-0e45-a6e8-437f9ee96292",
  CellID->78835713],
-Cell[53552, 1293, 1179, 34, 141, "Input",ExpressionUUID->"b99c382e-9027-c64e-a409-16a28d4663c3",
+Cell[62446, 1520, 1179, 34, 139, "Input",ExpressionUUID->"b99c382e-9027-c64e-a409-16a28d4663c3",
  CellID->35451050]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[54768, 1332, 240, 5, 20, "ExampleDelimiter",ExpressionUUID->"05fc0fe4-70c9-6545-bdd9-4be99d3d1395",
+Cell[63662, 1559, 240, 5, 16, "ExampleDelimiter",ExpressionUUID->"05fc0fe4-70c9-6545-bdd9-4be99d3d1395",
  CellID->8004203],
-Cell[55011, 1339, 1064, 18, 77, "ExampleText",ExpressionUUID->"b14ef85e-62ef-be48-ab21-3877b825833e",
+Cell[63905, 1566, 1064, 18, 71, "ExampleText",ExpressionUUID->"b14ef85e-62ef-be48-ab21-3877b825833e",
  CellID->159657629],
-Cell[56078, 1359, 759, 15, 43, "Input",ExpressionUUID->"519611c8-75f2-f44c-9ec9-f910fc244df0",
+Cell[64972, 1586, 759, 15, 42, "Input",ExpressionUUID->"519611c8-75f2-f44c-9ec9-f910fc244df0",
  CellID->90165992],
 Cell[CellGroupData[{
-Cell[56862, 1378, 1520, 27, 43, "Input",ExpressionUUID->"6c596d02-90f5-d146-8be1-f3356df845bb",
+Cell[65756, 1605, 1520, 27, 42, "Input",ExpressionUUID->"6c596d02-90f5-d146-8be1-f3356df845bb",
  CellID->127721805],
-Cell[58385, 1407, 2800, 61, 224, "Output",ExpressionUUID->"4cf1493e-b455-c243-9db9-882346e7505a",
+Cell[67279, 1634, 2800, 61, 222, "Output",ExpressionUUID->"4cf1493e-b455-c243-9db9-882346e7505a",
  CellID->753181186]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[61234, 1474, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"95c5af2e-83e2-c049-ad95-26256e2f5154",
+Cell[70128, 1701, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"95c5af2e-83e2-c049-ad95-26256e2f5154",
  CellID->659468086],
-Cell[61479, 1481, 286, 4, 24, "ExampleText",ExpressionUUID->"987a05e3-a7ad-a544-b563-b693fa6f47d2",
+Cell[70373, 1708, 286, 4, 23, "ExampleText",ExpressionUUID->"987a05e3-a7ad-a544-b563-b693fa6f47d2",
  CellID->14052528],
-Cell[61768, 1487, 1115, 20, 43, "Input",ExpressionUUID->"87dcd6b9-c690-7e4a-b858-6909cb94d6c3",
+Cell[70662, 1714, 1115, 20, 42, "Input",ExpressionUUID->"87dcd6b9-c690-7e4a-b858-6909cb94d6c3",
  CellID->633400500],
 Cell[CellGroupData[{
-Cell[62908, 1511, 899, 22, 61, "Input",ExpressionUUID->"b90a0632-2b9c-434a-9376-b729453d40c5",
+Cell[71802, 1738, 899, 22, 60, "Input",ExpressionUUID->"b90a0632-2b9c-434a-9376-b729453d40c5",
  CellID->857781487],
-Cell[63810, 1535, 2491, 57, 224, "Output",ExpressionUUID->"8ced13b3-63d0-8d45-8dd7-723f3c271ea8",
+Cell[72704, 1762, 2491, 57, 222, "Output",ExpressionUUID->"8ced13b3-63d0-8d45-8dd7-723f3c271ea8",
  CellID->484200114]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[66350, 1598, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"10fb8044-d833-814d-8428-5bf3f7df9346",
+Cell[75244, 1825, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"10fb8044-d833-814d-8428-5bf3f7df9346",
  CellID->894366129],
-Cell[66595, 1605, 1252, 24, 62, "ExampleText",ExpressionUUID->"46243403-2377-eb49-9ebf-40693e875f3e",
+Cell[75489, 1832, 1252, 24, 55, "ExampleText",ExpressionUUID->"46243403-2377-eb49-9ebf-40693e875f3e",
  CellID->117730622],
-Cell[67850, 1631, 975, 18, 43, "Input",ExpressionUUID->"f3abe340-b842-8549-9bcc-35fdeae4c777",
+Cell[76744, 1858, 975, 18, 42, "Input",ExpressionUUID->"f3abe340-b842-8549-9bcc-35fdeae4c777",
  CellID->6395788],
-Cell[68828, 1651, 1265, 34, 78, "Input",ExpressionUUID->"756f6c00-4cbd-d740-b96b-27b4eb1883fb",
+Cell[77722, 1878, 1265, 34, 77, "Input",ExpressionUUID->"756f6c00-4cbd-d740-b96b-27b4eb1883fb",
  CellID->29715377],
-Cell[70096, 1687, 1139, 31, 78, "Input",ExpressionUUID->"2c21b325-a480-8d4f-b6bf-579aa3b2fe1b",
+Cell[78990, 1914, 1139, 31, 77, "Input",ExpressionUUID->"2c21b325-a480-8d4f-b6bf-579aa3b2fe1b",
  CellID->155041588],
 Cell[CellGroupData[{
-Cell[71260, 1722, 948, 22, 78, "Input",ExpressionUUID->"804403bc-dad2-0d43-bce2-6e1d2f45a281",
+Cell[80154, 1949, 948, 22, 77, "Input",ExpressionUUID->"804403bc-dad2-0d43-bce2-6e1d2f45a281",
  CellID->716857752],
-Cell[72211, 1746, 837, 22, 35, "Output",ExpressionUUID->"6bc136ed-d148-6949-a60c-bd3b6457236e",
+Cell[81105, 1973, 837, 22, 33, "Output",ExpressionUUID->"6bc136ed-d148-6949-a60c-bd3b6457236e",
  CellID->293199232]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[73085, 1773, 941, 21, 78, "Input",ExpressionUUID->"1e5b207d-23f8-d44c-afb3-9700f3986449",
+Cell[81979, 2000, 941, 21, 77, "Input",ExpressionUUID->"1e5b207d-23f8-d44c-afb3-9700f3986449",
  CellID->21816214],
-Cell[74029, 1796, 2251, 53, 224, "Output",ExpressionUUID->"24849a3f-e5da-3c44-8391-4c5752ad0833",
+Cell[82923, 2023, 2251, 53, 222, "Output",ExpressionUUID->"24849a3f-e5da-3c44-8391-4c5752ad0833",
  CellID->201795981]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[76329, 1855, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"b976ae74-6b35-2d45-98b1-6fe571c979a9",
+Cell[85223, 2082, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"b976ae74-6b35-2d45-98b1-6fe571c979a9",
  CellID->320137623],
-Cell[76574, 1862, 900, 17, 60, "ExampleText",ExpressionUUID->"c1cab9fe-eb87-d346-b31b-d6fb786d909c",
+Cell[85468, 2089, 900, 17, 55, "ExampleText",ExpressionUUID->"c1cab9fe-eb87-d346-b31b-d6fb786d909c",
  CellID->505606112],
-Cell[77477, 1881, 1008, 19, 43, "Input",ExpressionUUID->"47039000-32a1-5241-bd3a-50cef22daa71",
+Cell[86371, 2108, 1008, 19, 42, "Input",ExpressionUUID->"47039000-32a1-5241-bd3a-50cef22daa71",
  CellID->63697933],
-Cell[78488, 1902, 1767, 51, 224, "Input",ExpressionUUID->"6ece76b5-3a26-2f4e-a7d8-1d1826a648b3",
+Cell[87382, 2129, 1767, 51, 222, "Input",ExpressionUUID->"6ece76b5-3a26-2f4e-a7d8-1d1826a648b3",
  CellID->66478949]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[80304, 1959, 487, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"ff8d6064-9f88-a74d-a8fa-17fb12f09124",
+Cell[89198, 2186, 487, 13, 56, "ExtendedExamplesSection",ExpressionUUID->"ff8d6064-9f88-a74d-a8fa-17fb12f09124",
  CellTags->"ExtendedExamples",
  CellID->326378688],
 Cell[CellGroupData[{
-Cell[80816, 1976, 241, 5, 35, "ExampleSection",ExpressionUUID->"ebb90dbe-6521-1749-85f4-6322f2026666",
+Cell[89710, 2203, 241, 5, 32, "ExampleSection",ExpressionUUID->"ebb90dbe-6521-1749-85f4-6322f2026666",
  CellID->452520281],
 Cell[CellGroupData[{
-Cell[81082, 1985, 182, 2, 24, "ExampleSubsection",ExpressionUUID->"334be610-900d-484f-bfe1-0437124d3430",
+Cell[89976, 2212, 182, 2, 23, "ExampleSubsection",ExpressionUUID->"334be610-900d-484f-bfe1-0437124d3430",
  CellID->198501545],
-Cell[81267, 1989, 1486, 22, 41, "ExampleText",ExpressionUUID->"91fe3dfc-3f15-2f41-b51e-992a9ff0e4f7",
+Cell[90161, 2216, 1486, 22, 39, "ExampleText",ExpressionUUID->"91fe3dfc-3f15-2f41-b51e-992a9ff0e4f7",
  CellID->723133349],
-Cell[82756, 2013, 783, 16, 43, "Input",ExpressionUUID->"fec21a5a-82ed-244f-97fc-0446c56b9ba0",
+Cell[91650, 2240, 783, 16, 42, "Input",ExpressionUUID->"fec21a5a-82ed-244f-97fc-0446c56b9ba0",
  CellID->407621152],
 Cell[CellGroupData[{
-Cell[83564, 2033, 656, 14, 25, "Input",ExpressionUUID->"c17fcdcd-8be0-214d-a8d2-54170e4bc6aa",
+Cell[92458, 2260, 656, 14, 25, "Input",ExpressionUUID->"c17fcdcd-8be0-214d-a8d2-54170e4bc6aa",
  CellID->244028921],
-Cell[84223, 2049, 2004, 58, 60, "Output",ExpressionUUID->"5d19e433-0e1c-6946-8021-a1acdcb9c8c6",
+Cell[93117, 2276, 2004, 58, 59, "Output",ExpressionUUID->"5d19e433-0e1c-6946-8021-a1acdcb9c8c6",
  CellID->21782229]
 }, Open  ]],
-Cell[86242, 2110, 1148, 27, 43, "Input",ExpressionUUID->"52baf7bd-c6f4-074e-9923-7c3ac2aac08e",
+Cell[95136, 2337, 1148, 27, 42, "Input",ExpressionUUID->"52baf7bd-c6f4-074e-9923-7c3ac2aac08e",
  CellID->197552022],
-Cell[87393, 2139, 1125, 23, 61, "Input",ExpressionUUID->"2da09c04-9266-9e4b-95aa-57649bab3d8a",
+Cell[96287, 2366, 1125, 23, 60, "Input",ExpressionUUID->"2da09c04-9266-9e4b-95aa-57649bab3d8a",
  CellID->233229007],
 Cell[CellGroupData[{
-Cell[88543, 2166, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"7fae9970-dc68-e245-9f46-8994f5ee5141",
+Cell[97437, 2393, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"7fae9970-dc68-e245-9f46-8994f5ee5141",
  CellID->631233377],
-Cell[88788, 2173, 982, 19, 60, "ExampleText",ExpressionUUID->"7d2792ed-a50c-dc42-b7cf-2eebc24cfb54",
+Cell[97682, 2400, 982, 19, 55, "ExampleText",ExpressionUUID->"7d2792ed-a50c-dc42-b7cf-2eebc24cfb54",
  CellID->293180495],
-Cell[89773, 2194, 1000, 21, 61, "Input",ExpressionUUID->"721a1c35-bfb5-0948-bee2-ceebc38af976",
+Cell[98667, 2421, 1000, 21, 60, "Input",ExpressionUUID->"721a1c35-bfb5-0948-bee2-ceebc38af976",
  CellID->272350353],
 Cell[CellGroupData[{
-Cell[90798, 2219, 560, 13, 25, "Input",ExpressionUUID->"f5eef431-c9c4-9e46-831b-8a35c8a2687d",
+Cell[99692, 2446, 560, 13, 25, "Input",ExpressionUUID->"f5eef431-c9c4-9e46-831b-8a35c8a2687d",
  CellID->160919502],
-Cell[91361, 2234, 1955, 58, 60, "Output",ExpressionUUID->"43fa3a2f-af06-4e4e-ad6f-5ece44240063",
+Cell[100255, 2461, 1955, 58, 59, "Output",ExpressionUUID->"43fa3a2f-af06-4e4e-ad6f-5ece44240063",
  CellID->6363342]
 }, Open  ]],
-Cell[93331, 2295, 1153, 27, 61, "Input",ExpressionUUID->"483ecfc5-709b-8146-8dd0-098ca38a4797",
+Cell[102225, 2522, 1153, 27, 60, "Input",ExpressionUUID->"483ecfc5-709b-8146-8dd0-098ca38a4797",
  CellID->102614535],
 Cell[CellGroupData[{
-Cell[94509, 2326, 1048, 23, 78, "Input",ExpressionUUID->"6fd7a3ab-5bae-dd4d-9f73-aef3ac7c4285",
+Cell[103403, 2553, 1048, 23, 77, "Input",ExpressionUUID->"6fd7a3ab-5bae-dd4d-9f73-aef3ac7c4285",
  CellID->128440207],
-Cell[95560, 2351, 1684, 44, 65, "Output",ExpressionUUID->"2b67ed65-a4c7-b040-9cd9-ec60e20e40d2",
+Cell[104454, 2578, 1684, 44, 63, "Output",ExpressionUUID->"2b67ed65-a4c7-b040-9cd9-ec60e20e40d2",
  CellID->90272515]
 }, Open  ]],
-Cell[97259, 2398, 1333, 26, 78, "Input",ExpressionUUID->"e9d4adb0-50e5-924f-8e3e-6b7e5ea18180",
+Cell[106153, 2625, 1333, 26, 77, "Input",ExpressionUUID->"e9d4adb0-50e5-924f-8e3e-6b7e5ea18180",
  CellID->293997694]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
-Cell[98631, 2429, 264, 5, 35, "ExampleSection",ExpressionUUID->"c3540bf7-4f16-c642-a969-4ed7094638b3",
+Cell[107525, 2656, 264, 5, 32, "ExampleSection",ExpressionUUID->"c3540bf7-4f16-c642-a969-4ed7094638b3",
  CellID->112538656],
 Cell[CellGroupData[{
-Cell[98920, 2438, 243, 5, 23, "ExampleSection",ExpressionUUID->"48157590-5f28-1c47-b312-e61b33053c9b",
+Cell[107814, 2665, 243, 5, 20, "ExampleSection",ExpressionUUID->"48157590-5f28-1c47-b312-e61b33053c9b",
  CellID->476698288],
 Cell[CellGroupData[{
-Cell[99188, 2447, 317, 6, 26, "ExampleSubsection",ExpressionUUID->"451e5695-341a-c546-a778-98db479c45a9",
+Cell[108082, 2674, 317, 6, 23, "ExampleSubsection",ExpressionUUID->"451e5695-341a-c546-a778-98db479c45a9",
  CellID->200887691],
-Cell[99508, 2455, 276, 5, 24, "ExampleText",ExpressionUUID->"ccdbb751-605f-4445-a640-a25ca2709b72",
+Cell[108402, 2682, 276, 5, 23, "ExampleText",ExpressionUUID->"ccdbb751-605f-4445-a640-a25ca2709b72",
  CellID->654805157],
 Cell[CellGroupData[{
-Cell[99809, 2464, 2403, 56, 166, "Input",ExpressionUUID->"5ae1ea12-31b6-a34d-b277-c8e18ed2b10b",
+Cell[108703, 2691, 2403, 56, 165, "Input",ExpressionUUID->"5ae1ea12-31b6-a34d-b277-c8e18ed2b10b",
  CellID->1148403],
-Cell[102215, 2522, 828, 17, 24, "Output",ExpressionUUID->"b1bc5949-29ec-f243-a200-dbc171b8e13c",
+Cell[111109, 2749, 828, 17, 24, "Output",ExpressionUUID->"b1bc5949-29ec-f243-a200-dbc171b8e13c",
  CellID->259030309]
 }, Open  ]],
-Cell[103058, 2542, 754, 15, 43, "ExampleText",ExpressionUUID->"cfb008d8-df29-0b45-8346-1d6404a3be97",
+Cell[111952, 2769, 754, 15, 39, "ExampleText",ExpressionUUID->"cfb008d8-df29-0b45-8346-1d6404a3be97",
  CellID->8011592],
-Cell[103815, 2559, 1370, 35, 45, "ExampleText",ExpressionUUID->"d4255562-a5f7-0f4a-af7f-f6cd3b92ca28",
+Cell[112709, 2786, 1370, 35, 39, "ExampleText",ExpressionUUID->"d4255562-a5f7-0f4a-af7f-f6cd3b92ca28",
  CellID->641512217]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[105222, 2599, 379, 7, 26, "ExampleSubsection",ExpressionUUID->"0e375e75-e1de-2c47-a1c0-f7a50b70a9ca",
+Cell[114116, 2826, 379, 7, 23, "ExampleSubsection",ExpressionUUID->"0e375e75-e1de-2c47-a1c0-f7a50b70a9ca",
  CellID->1036996805],
-Cell[105604, 2608, 1165, 29, 45, "ExampleText",ExpressionUUID->"558e6c8a-e58a-644a-88f3-9751d9d9522a",
+Cell[114498, 2835, 1165, 29, 39, "ExampleText",ExpressionUUID->"558e6c8a-e58a-644a-88f3-9751d9d9522a",
  CellID->1975506230],
-Cell[106772, 2639, 609, 11, 25, "Input",ExpressionUUID->"380a173b-5e67-7940-aa26-27c4fc9c0549",
+Cell[115666, 2866, 609, 11, 25, "Input",ExpressionUUID->"380a173b-5e67-7940-aa26-27c4fc9c0549",
  CellID->88541343],
 Cell[CellGroupData[{
-Cell[107406, 2654, 551, 12, 43, "Input",ExpressionUUID->"c017836a-e98a-5240-92f7-4b4bbddc50df",
+Cell[116300, 2881, 551, 12, 42, "Input",ExpressionUUID->"c017836a-e98a-5240-92f7-4b4bbddc50df",
  CellID->150127483],
-Cell[107960, 2668, 8498, 176, 53, "Output",ExpressionUUID->"5e3970ac-1c3d-1748-a69c-7f5e303c139e",
+Cell[116854, 2895, 8498, 176, 50, "Output",ExpressionUUID->"5e3970ac-1c3d-1748-a69c-7f5e303c139e",
  CellID->59323161]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[116495, 2849, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"d6917866-9ad9-5542-b0ed-240d114110d9",
+Cell[125389, 3076, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"d6917866-9ad9-5542-b0ed-240d114110d9",
  CellID->117913872],
-Cell[116740, 2856, 1220, 31, 45, "ExampleText",ExpressionUUID->"a7353174-267f-1347-adbc-3cd9cd8a782d",
+Cell[125634, 3083, 1220, 31, 39, "ExampleText",ExpressionUUID->"a7353174-267f-1347-adbc-3cd9cd8a782d",
  CellID->77617597],
-Cell[117963, 2889, 802, 16, 43, "Input",ExpressionUUID->"60dd7b09-9a16-3d48-b3ac-607ede755324",
+Cell[126857, 3116, 802, 16, 42, "Input",ExpressionUUID->"60dd7b09-9a16-3d48-b3ac-607ede755324",
  CellID->111045181],
 Cell[CellGroupData[{
-Cell[118790, 2909, 739, 16, 43, "Input",ExpressionUUID->"c74ad2dc-f06e-ac49-a1bd-83b77f67cac2",
+Cell[127684, 3136, 739, 16, 42, "Input",ExpressionUUID->"c74ad2dc-f06e-ac49-a1bd-83b77f67cac2",
  CellID->146570750],
-Cell[119532, 2927, 11367, 231, 53, "Output",ExpressionUUID->"9e022a2e-af24-9349-af27-5a344d8f2b85",
+Cell[128426, 3154, 11367, 231, 50, "Output",ExpressionUUID->"9e022a2e-af24-9349-af27-5a344d8f2b85",
  CellID->213302025]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
-Cell[130950, 3164, 248, 5, 35, "ExampleSection",ExpressionUUID->"206cc408-b3fa-7e40-9802-13411716b1ae",
+Cell[139844, 3391, 248, 5, 32, "ExampleSection",ExpressionUUID->"206cc408-b3fa-7e40-9802-13411716b1ae",
  CellID->466091341],
 Cell[CellGroupData[{
-Cell[131223, 3173, 258, 5, 23, "ExampleSection",ExpressionUUID->"4b5afd69-30b0-f549-a027-fda2dd3b83dc",
+Cell[140117, 3400, 258, 5, 20, "ExampleSection",ExpressionUUID->"4b5afd69-30b0-f549-a027-fda2dd3b83dc",
  CellID->113613961],
 Cell[CellGroupData[{
-Cell[131506, 3182, 767, 14, 28, "ExampleSubsection",ExpressionUUID->"998b3398-46d9-a441-93a4-7718f68d2e53",
+Cell[140400, 3409, 767, 14, 23, "ExampleSubsection",ExpressionUUID->"998b3398-46d9-a441-93a4-7718f68d2e53",
  CellID->296669070],
-Cell[132276, 3198, 1648, 25, 60, "ExampleText",ExpressionUUID->"7fae03ca-b5ec-1445-82d3-872a8360a200",
+Cell[141170, 3425, 1703, 26, 55, "ExampleText",ExpressionUUID->"7fae03ca-b5ec-1445-82d3-872a8360a200",
  CellID->105689035],
-Cell[133927, 3225, 1543, 26, 41, "ExampleText",ExpressionUUID->"f0c703c0-675d-604c-b432-3e835efa8bb9",
+Cell[142876, 3453, 1543, 26, 39, "ExampleText",ExpressionUUID->"f0c703c0-675d-604c-b432-3e835efa8bb9",
  CellID->709734105],
-Cell[135473, 3253, 1444, 28, 77, "ExampleText",ExpressionUUID->"e1347469-3698-e04d-b3cd-80a0661f52d5",
+Cell[144422, 3481, 1492, 28, 71, "ExampleText",ExpressionUUID->"e1347469-3698-e04d-b3cd-80a0661f52d5",
  CellID->105347582],
-Cell[136920, 3283, 2507, 56, 159, "Input",ExpressionUUID->"6905becd-107c-0c40-a828-6d33a66536e2",
+Cell[145917, 3511, 2507, 56, 158, "Input",ExpressionUUID->"6905becd-107c-0c40-a828-6d33a66536e2",
  CellID->448289478],
-Cell[139430, 3341, 1062, 16, 58, "ExampleText",ExpressionUUID->"b900a028-a822-464c-b723-e8bfc1d1476e",
+Cell[148427, 3569, 1062, 16, 55, "ExampleText",ExpressionUUID->"b900a028-a822-464c-b723-e8bfc1d1476e",
  CellID->135010306],
-Cell[140495, 3359, 1301, 20, 58, "ExampleText",ExpressionUUID->"e541d214-04a7-bb47-af31-cfed6716a9fe",
- CellID->359104851]
+Cell[149492, 3587, 1350, 21, 55, "ExampleText",ExpressionUUID->"e541d214-04a7-bb47-af31-cfed6716a9fe",
+ CellID->359104851],
+Cell[CellGroupData[{
+Cell[150867, 3612, 241, 5, 16, "ExampleDelimiter",ExpressionUUID->"90e3572b-3bc2-954e-acdf-2c2209c4376d",
+ CellID->41691713],
+Cell[151111, 3619, 1920, 29, 71, "ExampleText",ExpressionUUID->"7879bff2-3886-2a43-9c05-3019887669c4",
+ CellID->626781485],
+Cell[153034, 3650, 1961, 35, 55, "ExampleText",ExpressionUUID->"ddc09895-8ca9-8f42-8593-3dfa322b150c",
+ CellID->21247980],
+Cell[154998, 3687, 1974, 39, 87, "ExampleText",ExpressionUUID->"06029ee0-0624-264a-a3b9-4e23ea9b1bda",
+ CellID->85481949],
+Cell[156975, 3728, 1009, 19, 42, "Input",ExpressionUUID->"fc0bec1d-c824-994c-8b82-8ed62b5098f8",
+ CellID->219430595],
+Cell[157987, 3749, 1942, 57, 222, "Input",ExpressionUUID->"0007b8f0-acb1-e04c-a6a7-76f76156aad4",
+ CellID->676015994],
+Cell[159932, 3808, 1062, 16, 55, "ExampleText",ExpressionUUID->"6b99138a-4076-cf45-a631-dc753e98a605",
+ CellID->397014181],
+Cell[160997, 3826, 1527, 25, 55, "ExampleText",ExpressionUUID->"c4d37578-6565-334c-b1fa-0d179c17ecf1",
+ CellID->179261880]
+}, Open  ]]
 }, Open  ]]
 }, Open  ]],
-Cell[141823, 3383, 251, 5, 35, "ExampleSection",ExpressionUUID->"4136bfca-ccae-4543-a89e-4ab36f7c6c92",
+Cell[162563, 3856, 251, 5, 32, "ExampleSection",ExpressionUUID->"4136bfca-ccae-4543-a89e-4ab36f7c6c92",
  CellID->594336563],
-Cell[142077, 3390, 256, 5, 23, "ExampleSection",ExpressionUUID->"b4c36045-96ed-834c-b920-7ee3972a6426",
+Cell[162817, 3863, 256, 5, 20, "ExampleSection",ExpressionUUID->"b4c36045-96ed-834c-b920-7ee3972a6426",
  CellID->763924802],
-Cell[142336, 3397, 248, 5, 23, "ExampleSection",ExpressionUUID->"06f28036-9ba1-174d-8b77-006aea84e464",
+Cell[163076, 3870, 248, 5, 20, "ExampleSection",ExpressionUUID->"06f28036-9ba1-174d-8b77-006aea84e464",
  CellID->76990128]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[142621, 3407, 109, 1, 72, "MetadataSection",ExpressionUUID->"01514484-f4d3-1046-88ee-2933f6f10c3c",
+Cell[163361, 3880, 109, 1, 71, "MetadataSection",ExpressionUUID->"01514484-f4d3-1046-88ee-2933f6f10c3c",
  CellID->42901253],
-Cell[142733, 3410, 473, 12, 26, "History",ExpressionUUID->"b24f5e18-8dc2-7c42-9e60-5eb0c5a2f27f",
+Cell[163473, 3883, 473, 12, 25, "History",ExpressionUUID->"b24f5e18-8dc2-7c42-9e60-5eb0c5a2f27f",
  CellID->969934],
 Cell[CellGroupData[{
-Cell[143231, 3426, 484, 13, 21, "CategorizationSection",ExpressionUUID->"54061416-e7a9-2f4a-be70-40d9b092ffe3",
+Cell[163971, 3899, 484, 13, 20, "CategorizationSection",ExpressionUUID->"54061416-e7a9-2f4a-be70-40d9b092ffe3",
  CellID->155892578],
-Cell[143718, 3441, 134, 2, 35, "Categorization",ExpressionUUID->"d38e05c9-59d0-a44b-ad25-467dfb60ec55",
+Cell[164458, 3914, 134, 2, 35, "Categorization",ExpressionUUID->"d38e05c9-59d0-a44b-ad25-467dfb60ec55",
  CellID->379313778],
-Cell[143855, 3445, 159, 2, 35, "Categorization",ExpressionUUID->"f8011cf6-d3ee-0149-a640-c6d486bf3660",
+Cell[164595, 3918, 159, 2, 35, "Categorization",ExpressionUUID->"f8011cf6-d3ee-0149-a640-c6d486bf3660",
  CellID->123752965],
-Cell[144017, 3449, 156, 2, 35, "Categorization",ExpressionUUID->"c2aaec4f-b9fb-7c4e-ac7d-63c6d46998c8",
+Cell[164757, 3922, 156, 2, 35, "Categorization",ExpressionUUID->"c2aaec4f-b9fb-7c4e-ac7d-63c6d46998c8",
  CellID->207073079],
-Cell[144176, 3453, 355, 7, 35, "Categorization",ExpressionUUID->"ffab9e82-e6de-3843-8507-c30bd9940ae6",
+Cell[164916, 3926, 355, 7, 35, "Categorization",ExpressionUUID->"ffab9e82-e6de-3843-8507-c30bd9940ae6",
  CellID->485781109]
 }, Closed]],
 Cell[CellGroupData[{
-Cell[144568, 3465, 109, 1, 21, "KeywordsSection",ExpressionUUID->"9948f113-07ed-b749-a7c7-02455661517b",
+Cell[165308, 3938, 109, 1, 20, "KeywordsSection",ExpressionUUID->"9948f113-07ed-b749-a7c7-02455661517b",
  CellID->55111812],
-Cell[144680, 3468, 98, 1, 70, "Keywords",ExpressionUUID->"13a5388c-964d-e948-88a8-f2bed6c00cae",
+Cell[165420, 3941, 98, 1, 70, "Keywords",ExpressionUUID->"13a5388c-964d-e948-88a8-f2bed6c00cae",
  CellID->78694749]
 }, Closed]],
 Cell[CellGroupData[{
-Cell[144815, 3474, 119, 1, 21, "TemplatesSection",ExpressionUUID->"6439de18-e57c-d548-bfa1-0f1cff993b74",
+Cell[165555, 3947, 119, 1, 20, "TemplatesSection",ExpressionUUID->"6439de18-e57c-d548-bfa1-0f1cff993b74",
  CellID->272215535],
-Cell[144937, 3477, 148, 2, 70, "Template",ExpressionUUID->"9a729cf7-1198-3c4b-b13a-f189371bdae6",
+Cell[165677, 3950, 148, 2, 70, "Template",ExpressionUUID->"9a729cf7-1198-3c4b-b13a-f189371bdae6",
  CellID->476199561],
-Cell[145088, 3481, 136, 2, 70, "Template",ExpressionUUID->"4d280ee1-1eaf-df45-bf64-789cd00641a2",
+Cell[165828, 3954, 136, 2, 70, "Template",ExpressionUUID->"4d280ee1-1eaf-df45-bf64-789cd00641a2",
  CellID->39443153],
-Cell[145227, 3485, 135, 2, 70, "Template",ExpressionUUID->"fe3509c5-ddbf-f84d-a38d-d2582ffef23c",
+Cell[165967, 3958, 135, 2, 70, "Template",ExpressionUUID->"fe3509c5-ddbf-f84d-a38d-d2582ffef23c",
  CellID->140411135],
-Cell[145365, 3489, 135, 2, 70, "Template",ExpressionUUID->"e2d612c8-c48e-c943-824b-d02a310bb682",
+Cell[166105, 3962, 135, 2, 70, "Template",ExpressionUUID->"e2d612c8-c48e-c943-824b-d02a310bb682",
  CellID->8216975]
 }, Closed]]
 }, Open  ]]

--- a/Paclet/Documentation/English/ReferencePages/Symbols/NonReciprocalTBHamiltonian.nb
+++ b/Paclet/Documentation/English/ReferencePages/Symbols/NonReciprocalTBHamiltonian.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[    151474,       3628]
-NotebookOptionsPosition[    135074,       3287]
-NotebookOutlinePosition[    135853,       3312]
-CellTagsIndexPosition[    135772,       3307]
+NotebookDataLength[    162862,       3854]
+NotebookOptionsPosition[    145528,       3495]
+NotebookOutlinePosition[    146307,       3520]
+CellTagsIndexPosition[    146226,       3515]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -42,8 +42,8 @@ Cell[TextData[{
     StyleBox["hoppingsCanonical", "TI"], ",", 
     StyleBox["hoppingsOpposite", "TI"]}], "]"}]], "InlineFormula",
   ExpressionUUID->"6c4c0ed1-1006-4499-b140-9ff19475cbdb"],
- " \[LineSeparator]returns the tight-binding Hamiltonian H with open boundary \
-conditions of the  ",
+ " \[LineSeparator]returns the non-reciprocal tight-binding Hamiltonian H \
+with open boundary conditions of the  ",
  Cell[BoxData[
   ButtonBox["HCModelGraph",
    BaseStyle->"Link",
@@ -98,7 +98,8 @@ site specified by ",
     StyleBox["hoppingsCanonicalGluedEdges", "TI"], ",", 
     StyleBox["hoppingsOppositeGluedEdges", "TI"]}], "]"}]], "InlineFormula",
   ExpressionUUID->"70bdd5d3-8a1c-7b4e-967f-e37bd8549455"],
- " \[LineSeparator]returns the tight-binding Hamiltonian H of the ",
+ " \[LineSeparator]returns the non-reciprocal tight-binding Hamiltonian H of \
+the ",
  Cell[BoxData[
   StyleBox["mgraph", "TI"]], "InlineFormula",ExpressionUUID->
   "1dadbbd0-aab5-b049-bf7b-f536e37f67ea"],
@@ -183,13 +184,14 @@ HBDisclinationSupercellModelGraph"]], "InlineFormula",ExpressionUUID->
    3.940094346236191*^9}, {3.94009483199699*^9, 3.940094864946884*^9}, {
    3.9403574452289276`*^9, 3.940357601969015*^9}, {3.940357636029043*^9, 
    3.9403576446242714`*^9}, {3.9403576820451336`*^9, 3.940357781228964*^9}, {
-   3.940358022479147*^9, 3.9403580748039036`*^9}, {3.9403581883986893`*^9, 
+   3.940358022479147*^9, 3.940358074803903*^9}, {3.940358188398689*^9, 
    3.9403581888468*^9}, {3.940358220058737*^9, 3.940358221819124*^9}, {
    3.940359259285679*^9, 3.9403592626152782`*^9}, {3.9403596817698994`*^9, 
-   3.9403597712149353`*^9}, {3.940361531745716*^9, 3.9403615901465855`*^9}, {
-   3.9403616983631554`*^9, 3.9403617387518806`*^9}, {3.9403618000779877`*^9, 
-   3.940361826789921*^9}, {3.9403618749169292`*^9, 3.9403619003853188`*^9}, {
-   3.9403619546940136`*^9, 3.9403619647689095`*^9}, 3.940362113285675*^9},
+   3.940359771214936*^9}, {3.940361531745716*^9, 3.9403615901465855`*^9}, {
+   3.9403616983631554`*^9, 3.9403617387518806`*^9}, {3.9403618000779886`*^9, 
+   3.940361826789921*^9}, {3.9403618749169292`*^9, 3.940361900385319*^9}, {
+   3.940361954694014*^9, 3.9403619647689095`*^9}, 3.940362113285675*^9, {
+   3.9551676574719334`*^9, 3.955167673745249*^9}},
  CellID->207877341,ExpressionUUID->"5a95bc6d-6279-4563-9d22-a21d53dda161"],
 
 Cell[TextData[{
@@ -261,7 +263,7 @@ single number if ",
    3.937375408884691*^9, 3.937375423979957*^9}, {3.9373755279980526`*^9, 
    3.937375529538471*^9}, {3.937375589696427*^9, 3.937375610485981*^9}, {
    3.93738160140168*^9, 3.937381601766527*^9}, {3.93738643764258*^9, 
-   3.937386461051857*^9}, {3.9376572332256184`*^9, 3.9376572395768986`*^9}},
+   3.937386461051857*^9}, {3.937657233225618*^9, 3.937657239576898*^9}},
  CellID->8242630,ExpressionUUID->"6b8281bc-12b7-9049-85e4-33f8a90d46bf"],
 
 Cell[TextData[{
@@ -472,8 +474,9 @@ edge or a number if ",
   3.937649883978386*^9}},
  CellID->978527526,ExpressionUUID->"befd335a-f1a3-a742-adb8-bd6148e17917"],
 
-Cell["The following option can be given:", "Notes",
- CellChangeTimes->{{3.906026854624065*^9, 3.9060268604382353`*^9}},
+Cell["The following options can be given:", "Notes",
+ CellChangeTimes->{{3.906026854624065*^9, 3.9060268604382353`*^9}, 
+   3.9551676832368374`*^9},
  CellID->444168746,ExpressionUUID->"1c7289b5-700a-c54e-9a07-7e04882eec7b"],
 
 Cell[BoxData[GridBox[{
@@ -677,10 +680,10 @@ NonReciprocalAbelianBlochHamiltonian"]], "InlineSeeAlsoFunction",
     "429010f2-dc11-0d47-84f1-dce239246c39"], 
    DynamicModuleBox[{$CellContext`nbobj$$ = NotebookObject[
     "ca524783-33ba-4436-a7c7-e9b68abdb844", 
-     "6e2d45d4-94f6-5549-87ee-c2eb9e055371"], $CellContext`cellobj$$ = 
+     "1bc8fdf5-a8a3-e54e-9079-2074d1741c9a"], $CellContext`cellobj$$ = 
     CellObject[
     "33b21f5c-9fe9-244c-ae30-addab55a5b8a", 
-     "442518b7-d9e4-944e-8453-9777234b6870"]}, 
+     "c428abb0-4df0-4c4d-99ba-bd2d4b351c5c"]}, 
     TemplateBox[{
       GraphicsBox[{{
          Thickness[0.06], 
@@ -1070,7 +1073,7 @@ hopping amplitudes by using an ",
  CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
   3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
   3.906028831115154*^9}, {3.937387021017941*^9, 3.937387037942257*^9}, {
-  3.937387113437589*^9, 3.937387113584722*^9}, {3.9373871579103127`*^9, 
+  3.937387113437589*^9, 3.937387113584722*^9}, {3.937387157910314*^9, 
   3.9373871661530514`*^9}, {3.937387213061463*^9, 3.937387214953532*^9}, {
   3.9373874976717434`*^9, 3.9373874998650417`*^9}, {3.937388888891772*^9, 
   3.937388888891772*^9}, {3.937403143587374*^9, 3.9374031477680244`*^9}, {
@@ -1268,7 +1271,7 @@ per site:"
   3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
   3.906028831115154*^9}, {3.906028997135098*^9, 3.906029000923377*^9}, {
   3.937387806841976*^9, 3.937387828137247*^9}, {3.937388233551248*^9, 
-  3.937388251433483*^9}, {3.9376503457630672`*^9, 3.937650354703289*^9}, {
+  3.937388251433483*^9}, {3.937650345763067*^9, 3.937650354703289*^9}, {
   3.937657770415821*^9, 3.9376577745855465`*^9}},
  CellID->16699796,ExpressionUUID->"73bd323e-2983-3346-a43a-e9815c20bad5"],
 
@@ -1620,7 +1623,7 @@ hopping amplitudes by using an ",
  CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
   3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
   3.906028831115154*^9}, {3.937387021017941*^9, 3.937387037942257*^9}, {
-  3.937387113437589*^9, 3.937387113584722*^9}, {3.9373871579103127`*^9, 
+  3.937387113437589*^9, 3.937387113584722*^9}, {3.937387157910314*^9, 
   3.9373871661530514`*^9}, {3.937387213061463*^9, 3.937387214953532*^9}, {
   3.9373874976717434`*^9, 3.9373874998650417`*^9}, {3.937388888891772*^9, 
   3.937388888891772*^9}, {3.937403143587374*^9, 3.9374031477680244`*^9}},
@@ -3166,12 +3169,217 @@ Cell[BoxData[
   $Line = 0; Null]], "ExampleSection",
  CellID->466091341,ExpressionUUID->"206cc408-b3fa-7e40-9802-13411716b1ae"],
 
+Cell[CellGroupData[{
+
 Cell[BoxData[
  InterpretationBox[Cell[
   "Properties & Relations", "ExampleSection",ExpressionUUID->
    "b0c65480-3783-6e47-b956-c8e305ba54d2"],
   $Line = 0; Null]], "ExampleSection",
  CellID->113613961,ExpressionUUID->"4b5afd69-30b0-f549-a027-fda2dd3b83dc"],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ InterpretationBox[Cell[TextData[Cell[BoxData[
+   InterpretationBox[Cell[
+    "Multiple orbitals", "ExampleSubsection",ExpressionUUID->
+     "4ed33428-6cf1-0b4b-8bd2-5320667be46f"],
+    $Line = 0; Null]],
+   CellChangeTimes->{{3.9060313294514136`*^9, 3.906031330419829*^9}, {
+    3.9374005375764217`*^9, 3.937400540021569*^9}},ExpressionUUID->
+   "fa407eb2-e3fb-834d-b730-075cf680ad3f"]], "ExampleSubsection",
+   ExpressionUUID->"f6a17426-13e8-0d4e-ae7a-af443e905c25"],
+  $Line = 0; Null]], "ExampleSubsection",
+ CellChangeTimes->{{3.9060313294514136`*^9, 3.906031330419829*^9}, {
+  3.937405053908352*^9, 3.937405065322071*^9}, {3.9551680429373455`*^9, 
+  3.95516805009239*^9}},
+ CellID->296669070,ExpressionUUID->"998b3398-46d9-a441-93a4-7718f68d2e53"],
+
+Cell[TextData[{
+ "Non-reciprocal tight-binding Hamiltonians are generalizations of \
+tight-binding Hamiltonians, which can be constructed with the function  ",
+ Cell[BoxData[
+  ButtonBox["TBHamiltonian",
+   BaseStyle->"Link",
+   ButtonData->"paclet:PatrickMLenggenhager/HyperBloch/ref/TBHamiltonian"]], 
+  "InlineFormula",ExpressionUUID->"62876ae4-7e52-2d42-bf86-3739faa21ea6"],
+ ". As such, the onsite potential and the hopping amplitudes are specified \
+analogously. Crucially, the following convention is imposed:"
+}], "ExampleText",
+ CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
+   3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
+   3.906028831115154*^9}, {3.906028997135098*^9, 3.906029000923377*^9}, 
+   3.9345103390559063`*^9, {3.937421005016327*^9, 3.9374210159177094`*^9}, {
+   3.955167356777308*^9, 3.955167361081892*^9}, {3.955168934862646*^9, 
+   3.955168998679025*^9}, {3.9551691386825943`*^9, 3.955169194672315*^9}, {
+   3.955169256152302*^9, 3.955169493182674*^9}, {3.955169586572748*^9, 
+   3.955169712677645*^9}, {3.955169791552847*^9, 3.9551697986726894`*^9}, {
+   3.955169850973112*^9, 3.9551698519929743`*^9}, {3.955169927112825*^9, 
+   3.955170211827799*^9}, {3.955170242038122*^9, 3.955170255833084*^9}, {
+   3.955170301413376*^9, 3.955170391316994*^9}, {3.955170445563442*^9, 
+   3.9551705987731857`*^9}, {3.955176636663025*^9, 3.955176641047663*^9}, {
+   3.9551768148026085`*^9, 3.9551768275227795`*^9}, {3.955176863612985*^9, 
+   3.955176863612985*^9}, {3.9551786603626556`*^9, 3.9551787363078537`*^9}},
+ CellID->105689035,ExpressionUUID->"7fae03ca-b5ec-1445-82d3-872a8360a200"],
+
+Cell[TextData[{
+ "To specify the hopping matrix for the hopping amplitudes  ",
+ Cell[BoxData[
+  StyleBox["hoppingsOpposite", "TI"]], "InlineFormula",ExpressionUUID->
+  "d620aeb9-e007-6740-8547-245f6bb362a6"],
+ " appropriately, the positions of the matrix entries for each pair of \
+orbitals is inherited from the hopping matrix ",
+ Cell[BoxData[
+  StyleBox["hoppingsCanonical", "TI"]], "InlineFormula",ExpressionUUID->
+  "3e355822-8ee9-f54c-98e7-6530749b9e2b"],
+ ". "
+}], "ExampleText",
+ CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
+   3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
+   3.906028831115154*^9}, {3.906028997135098*^9, 3.906029000923377*^9}, 
+   3.9345103390559063`*^9, {3.937421005016327*^9, 3.9374210159177094`*^9}, {
+   3.955167356777308*^9, 3.955167361081892*^9}, {3.955168934862646*^9, 
+   3.955168998679025*^9}, {3.9551691386825943`*^9, 3.955169194672315*^9}, {
+   3.955169256152302*^9, 3.955169493182674*^9}, {3.955169586572748*^9, 
+   3.955169712677645*^9}, {3.955169791552847*^9, 3.9551697986726894`*^9}, {
+   3.955169850973112*^9, 3.9551698519929743`*^9}, {3.955169927112825*^9, 
+   3.955170211827799*^9}, {3.955170242038122*^9, 3.955170255833084*^9}, {
+   3.955170301413376*^9, 3.955170391316994*^9}, {3.955170445563442*^9, 
+   3.955170745103998*^9}, {3.95517080197999*^9, 3.955170813024542*^9}, {
+   3.955171255916292*^9, 3.9551712615131607`*^9}, {3.955172093403908*^9, 
+   3.955172093884252*^9}},
+ CellID->709734105,ExpressionUUID->"f0c703c0-675d-604c-b432-3e835efa8bb9"],
+
+Cell[TextData[{
+ "For example, the non-reciprocal Abelian Bloch Hamiltonian of a hopping \
+model defined on an ",
+ Cell[BoxData[
+  ButtonBox["HCModelGraph",
+   BaseStyle->"Link",
+   ButtonData->"paclet:PatrickMLenggenhager/HyperBloch/ref/HCModelGraph"]], 
+  "InlineFormula",ExpressionUUID->"dce7542b-9b3a-de46-920c-19d9a2c1cc9e"],
+ " (here the primitive cell of the {8,8} tessellation) with hopping \
+amplitudes ",
+ Cell[BoxData[
+  StyleBox["hoppingsCanonical", "TI"]], "InlineFormula",ExpressionUUID->
+  "bcc92f37-c462-4b47-bf90-40deea9f78ca"],
+ " in the canonical directions and ",
+ Cell[BoxData[
+  StyleBox["hoppingsOpposite", "TI"]], "InlineFormula",ExpressionUUID->
+  "cd32a374-d5b7-f04b-a01b-bacdbd048c9f"],
+ " in the opposite directions and two orbitals per site, using symbolic \
+arguments, is:"
+}], "ExampleText",
+ CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
+   3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
+   3.906028831115154*^9}, {3.906028997135098*^9, 3.906029000923377*^9}, 
+   3.9345103390559063`*^9, {3.937421005016327*^9, 3.9374210159177094`*^9}, {
+   3.9551673567773075`*^9, 3.955167361081892*^9}, {3.955169884838175*^9, 
+   3.955169900892893*^9}, {3.9551712636836224`*^9, 3.9551712747634583`*^9}, {
+   3.9551714818336887`*^9, 3.9551715032236137`*^9}, {3.955172112773716*^9, 
+   3.955172113753664*^9}},
+ CellID->105347582,ExpressionUUID->"e1347469-3698-e04d-b3cd-80a0661f52d5"],
+
+Cell[BoxData[{
+ RowBox[{
+  RowBox[{"modelgraph", "=", 
+   RowBox[{"HCExampleData", "[", "\"\<{8,3}-tess_T2.1_3.hcm\>\"", "]"}]}], 
+  ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"onsite", "=", 
+   RowBox[{
+    RowBox[{"(", GridBox[{
+       {"0", 
+        RowBox[{"-", "t1"}]},
+       {"t1", "0"}
+      }], ")"}], "&"}]}], ";"}], "\n", 
+ RowBox[{
+  RowBox[{"hoppingsCanonical", "=", 
+   RowBox[{
+    RowBox[{
+     RowBox[{"-", "t2"}], 
+     RowBox[{"(", GridBox[{
+        {"0", "1"},
+        {"1", "0"}
+       }], ")"}]}], "&"}]}], ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"hoppingsOpposite", " ", "=", 
+   RowBox[{
+    RowBox[{"t2", 
+     RowBox[{"(", GridBox[{
+        {"0", "1"},
+        {"1", "0"}
+       }], ")"}]}], "&"}]}], ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"NonReciprocalTBHamiltonian", "[", 
+   RowBox[{"modelgraph", ",", 
+    RowBox[{"2", "&"}], ",", "onsite", ",", "hoppingsCanonical", ",", 
+    "hoppingsOpposite"}], "]"}], ";"}]}], "Input",
+ CellChangeTimes->{{3.906027063408805*^9, 3.906027088319622*^9}, {
+   3.9060271833899145`*^9, 3.906027223799124*^9}, 3.906028315145218*^9, {
+   3.906028607996865*^9, 3.906028613837571*^9}, {3.9060286781196327`*^9, 
+   3.906028694807095*^9}, {3.906028732857873*^9, 3.906028753463425*^9}, {
+   3.906028853588249*^9, 3.906028970614804*^9}, {3.906029009568014*^9, 
+   3.9060291359216547`*^9}, 3.906435166479804*^9, 3.918641100224955*^9, 
+   3.918641526860538*^9, {3.934510346885731*^9, 3.934510363362161*^9}, {
+   3.934512248861981*^9, 3.934512249102097*^9}, {3.937421018680098*^9, 
+   3.937421039864488*^9}, 3.9551685771625175`*^9, {3.9551686636921463`*^9, 
+   3.9551686812375736`*^9}, {3.9551688907523804`*^9, 3.955168898442978*^9}, {
+   3.9551715089333115`*^9, 3.9551715174531784`*^9}, {3.9551722334739017`*^9, 
+   3.9551722813437862`*^9}, {3.9551731788246975`*^9, 
+   3.9551732107602386`*^9}, {3.955173241444565*^9, 3.9551732573395042`*^9}, {
+   3.9551736999744873`*^9, 3.955173717554676*^9}, {3.955173754074892*^9, 
+   3.9551737789347763`*^9}, {3.9551738764048176`*^9, 3.955173881875292*^9}, {
+   3.955173958940502*^9, 3.955173964274702*^9}, {3.955174224704588*^9, 
+   3.9551742286749134`*^9}, {3.955174273904991*^9, 3.9551742763650055`*^9}, {
+   3.955176305313349*^9, 3.9551763195034027`*^9}, {3.9551769472231007`*^9, 
+   3.9551769474131107`*^9}, {3.955177010687973*^9, 3.955177017082922*^9}, 
+   3.9551783292480373`*^9},
+ CellLabel->"In[1]:=",
+ CellID->448289478,ExpressionUUID->"6905becd-107c-0c40-a828-6d33a66536e2"],
+
+Cell["\<\
+Specifically, we have set the mass terms of the orbitals to zero, the \
+intra-site coupling to -t1 in the canonical direction and t1 in the opposite \
+direction and the inter-site coupling to -t2  in the canonical direction and \
+t2 in the opposite direction.\
+\>", "ExampleText",
+ CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
+   3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
+   3.906028831115154*^9}, {3.906028997135098*^9, 3.906029000923377*^9}, 
+   3.9345103390559063`*^9, {3.937421005016327*^9, 3.9374210159177094`*^9}, {
+   3.9551673567773075`*^9, 3.955167361081892*^9}, {3.955169884838175*^9, 
+   3.955169900892893*^9}, {3.9551712636836224`*^9, 3.9551712747634583`*^9}, {
+   3.9551714818336887`*^9, 3.9551715032236137`*^9}, {3.955172112773716*^9, 
+   3.955172113753664*^9}, {3.955172958744713*^9, 3.9551729998145275`*^9}, {
+   3.9551738888346024`*^9, 3.955174072975092*^9}, {3.955178351427471*^9, 
+   3.955178362197628*^9}},
+ CellID->135010306,ExpressionUUID->"b900a028-a822-464c-b723-e8bfc1d1476e"],
+
+Cell[TextData[{
+ "Note, for the specification of the hopping matrix ",
+ Cell[BoxData[
+  StyleBox["hoppingsOpposite", "TI"]], "InlineFormula",ExpressionUUID->
+  "0529fa61-edcd-4442-bb4b-dd3e7bc86909"],
+ " it is instructive to think of constructing an Abelian Bloch Hamiltonian \
+with adjusted hopping amplitudes. The location of the matrix entries, \
+signifying which orbitals are couped, are not to be adjusted."
+}], "ExampleText",
+ CellChangeTimes->{{3.906027105777158*^9, 3.906027175428211*^9}, {
+   3.9060285881964235`*^9, 3.90602860227144*^9}, {3.9060288129869814`*^9, 
+   3.906028831115154*^9}, {3.906028997135098*^9, 3.906029000923377*^9}, 
+   3.9345103390559063`*^9, {3.937421005016327*^9, 3.9374210159177094`*^9}, {
+   3.9551673567773075`*^9, 3.955167361081892*^9}, {3.955169884838175*^9, 
+   3.955169900892893*^9}, {3.9551712636836224`*^9, 3.9551712747634583`*^9}, {
+   3.9551714818336887`*^9, 3.9551715032236137`*^9}, {3.9551715785834274`*^9, 
+   3.955171787968336*^9}, {3.9551718215979214`*^9, 3.955171921880068*^9}, {
+   3.955171980553753*^9, 3.95517204996364*^9}, {3.9551721380934505`*^9, 
+   3.955172210473549*^9}, {3.955172312600815*^9, 3.95517231343186*^9}, {
+   3.955172798924677*^9, 3.9551728555947685`*^9}},
+ CellID->359104851,ExpressionUUID->"e541d214-04a7-bb47-af31-cfed6716a9fe"]
+}, Open  ]]
+}, Open  ]],
 
 Cell[BoxData[
  InterpretationBox[Cell[
@@ -3299,14 +3507,14 @@ ExpressionUUID->"ca524783-33ba-4436-a7c7-e9b68abdb844"
 (*CellTagsOutline
 CellTagsIndex->{
  "ExtendedExamples"->{
-  Cell[80211, 1956, 487, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"ff8d6064-9f88-a74d-a8fa-17fb12f09124",
+  Cell[80304, 1959, 487, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"ff8d6064-9f88-a74d-a8fa-17fb12f09124",
    CellTags->"ExtendedExamples",
    CellID->326378688]}
  }
 *)
 (*CellTagsIndex
 CellTagsIndex->{
- {"ExtendedExamples", 135577, 3300}
+ {"ExtendedExamples", 146031, 3508}
  }
 *)
 (*NotebookFileOutline
@@ -3314,319 +3522,337 @@ Notebook[{
 Cell[CellGroupData[{
 Cell[580, 22, 263, 3, 74, "ObjectName",ExpressionUUID->"153c8566-b789-49e1-9042-3899900e3b7a",
  CellID->641622780],
-Cell[846, 27, 7237, 165, 271, "Usage",ExpressionUUID->"5a95bc6d-6279-4563-9d22-a21d53dda161",
+Cell[846, 27, 7311, 167, 288, "Usage",ExpressionUUID->"5a95bc6d-6279-4563-9d22-a21d53dda161",
  CellID->207877341],
-Cell[8086, 194, 1606, 35, 48, "Notes",ExpressionUUID->"51a2fb5a-fade-4a72-bf0c-9242b370fb83",
+Cell[8160, 196, 1606, 35, 48, "Notes",ExpressionUUID->"51a2fb5a-fade-4a72-bf0c-9242b370fb83",
  CellID->140612745],
-Cell[9695, 231, 1486, 33, 48, "Notes",ExpressionUUID->"6b8281bc-12b7-9049-85e4-33f8a90d46bf",
+Cell[9769, 233, 1482, 33, 48, "Notes",ExpressionUUID->"6b8281bc-12b7-9049-85e4-33f8a90d46bf",
  CellID->8242630],
-Cell[11184, 266, 1511, 37, 90, "Notes",ExpressionUUID->"916d2e20-f426-4271-9d7c-a98609af83a2",
+Cell[11254, 268, 1511, 37, 90, "Notes",ExpressionUUID->"916d2e20-f426-4271-9d7c-a98609af83a2",
  CellID->122405462],
-Cell[12698, 305, 1608, 35, 48, "Notes",ExpressionUUID->"61fdac31-46a3-0740-85a1-4f9fb65c236b",
+Cell[12768, 307, 1608, 35, 48, "Notes",ExpressionUUID->"61fdac31-46a3-0740-85a1-4f9fb65c236b",
  CellID->372301786],
-Cell[14309, 342, 1485, 33, 48, "Notes",ExpressionUUID->"29c3eeb1-4bd4-fb41-8a8e-6a5cf6292032",
+Cell[14379, 344, 1485, 33, 48, "Notes",ExpressionUUID->"29c3eeb1-4bd4-fb41-8a8e-6a5cf6292032",
  CellID->96192577],
-Cell[15797, 377, 2213, 50, 90, "Notes",ExpressionUUID->"6ee1f639-78fc-9443-9db0-28a0b4f196ff",
+Cell[15867, 379, 2213, 50, 90, "Notes",ExpressionUUID->"6ee1f639-78fc-9443-9db0-28a0b4f196ff",
  CellID->258865958],
-Cell[18013, 429, 1675, 43, 90, "Notes",ExpressionUUID->"befd335a-f1a3-a742-adb8-bd6148e17917",
+Cell[18083, 431, 1675, 43, 90, "Notes",ExpressionUUID->"befd335a-f1a3-a742-adb8-bd6148e17917",
  CellID->978527526],
-Cell[19691, 474, 194, 2, 27, "Notes",ExpressionUUID->"1c7289b5-700a-c54e-9a07-7e04882eec7b",
+Cell[19761, 476, 223, 3, 27, "Notes",ExpressionUUID->"1c7289b5-700a-c54e-9a07-7e04882eec7b",
  CellID->444168746],
-Cell[19888, 478, 1770, 41, 103, "3ColumnTableMod",ExpressionUUID->"ef297d37-914b-8f42-bbda-f7d0f0fab73c",
+Cell[19987, 481, 1770, 41, 103, "3ColumnTableMod",ExpressionUUID->"ef297d37-914b-8f42-bbda-f7d0f0fab73c",
  CellID->65923218]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[21695, 524, 435, 12, 40, "TechNotesSection",ExpressionUUID->"0fea9c94-dcc9-4460-b773-0032ab8ec549",
+Cell[21794, 527, 435, 12, 40, "TechNotesSection",ExpressionUUID->"0fea9c94-dcc9-4460-b773-0032ab8ec549",
  CellID->995312194],
-Cell[22133, 538, 265, 6, 19, "Tutorials",ExpressionUUID->"1928c8e7-a68c-46a0-8cba-0ffff1419b9e",
+Cell[22232, 541, 265, 6, 19, "Tutorials",ExpressionUUID->"1928c8e7-a68c-46a0-8cba-0ffff1419b9e",
  CellID->151400]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[22435, 549, 472, 13, 39, "RelatedLinksSection",ExpressionUUID->"fecb14cf-25fa-4a0c-9894-8ca8438f0be1",
+Cell[22534, 552, 472, 13, 39, "RelatedLinksSection",ExpressionUUID->"fecb14cf-25fa-4a0c-9894-8ca8438f0be1",
  CellID->202509145],
-Cell[22910, 564, 103, 1, 19, "RelatedLinks",ExpressionUUID->"79cdcc1a-2b16-4dc9-9e2d-fc7a3173b09d",
+Cell[23009, 567, 103, 1, 19, "RelatedLinks",ExpressionUUID->"79cdcc1a-2b16-4dc9-9e2d-fc7a3173b09d",
  CellID->144199850]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[23050, 570, 458, 13, 39, "SeeAlsoSection",ExpressionUUID->"8abec620-8af0-574a-9875-b24068b2beef",
+Cell[23149, 573, 458, 13, 39, "SeeAlsoSection",ExpressionUUID->"8abec620-8af0-574a-9875-b24068b2beef",
  CellID->223461721],
-Cell[23511, 585, 5548, 130, 80, "SeeAlso",ExpressionUUID->"1af84081-07d0-944f-aa97-505b313e997c",
+Cell[23610, 588, 5548, 130, 80, "SeeAlso",ExpressionUUID->"1af84081-07d0-944f-aa97-505b313e997c",
  CellID->381155944]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[29096, 720, 182, 2, 39, "MoreAboutSection",ExpressionUUID->"628c56fb-2a64-454a-afda-0c72e8b98f07",
+Cell[29195, 723, 182, 2, 39, "MoreAboutSection",ExpressionUUID->"628c56fb-2a64-454a-afda-0c72e8b98f07",
  CellID->31221473],
-Cell[29281, 724, 281, 6, 19, "MoreAbout",ExpressionUUID->"f716947c-4c12-47a4-9cff-f2a24ce82555",
+Cell[29380, 727, 281, 6, 19, "MoreAbout",ExpressionUUID->"f716947c-4c12-47a4-9cff-f2a24ce82555",
  CellID->542581366]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[29599, 735, 530, 14, 69, "ExamplesInitializationSection",ExpressionUUID->"d27dce01-6ac7-4a45-a9d6-0701f911e181",
+Cell[29698, 738, 530, 14, 69, "ExamplesInitializationSection",ExpressionUUID->"d27dce01-6ac7-4a45-a9d6-0701f911e181",
  CellID->428868112],
-Cell[30132, 751, 306, 5, 45, "ExampleInitialization",ExpressionUUID->"b9b2fab4-94b0-40ca-9b3a-2f0308baac5d",
+Cell[30231, 754, 306, 5, 45, "ExampleInitialization",ExpressionUUID->"b9b2fab4-94b0-40ca-9b3a-2f0308baac5d",
  CellID->127019986]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[30475, 761, 441, 12, 71, "PrimaryExamplesSection",ExpressionUUID->"898c9691-0437-2b4f-911a-086c5248b0cc",
+Cell[30574, 764, 441, 12, 71, "PrimaryExamplesSection",ExpressionUUID->"898c9691-0437-2b4f-911a-086c5248b0cc",
  CellID->11026314],
-Cell[30919, 775, 1069, 18, 77, "ExampleText",ExpressionUUID->"665d84cd-aea7-8c4c-8c5b-c3de1f16dc2a",
+Cell[31018, 778, 1069, 18, 77, "ExampleText",ExpressionUUID->"665d84cd-aea7-8c4c-8c5b-c3de1f16dc2a",
  CellID->82755364],
-Cell[31991, 795, 608, 11, 25, "Input",ExpressionUUID->"cb9530ef-450c-3c4d-b5fb-7739129fba2c",
+Cell[32090, 798, 608, 11, 25, "Input",ExpressionUUID->"cb9530ef-450c-3c4d-b5fb-7739129fba2c",
  CellID->642833953],
 Cell[CellGroupData[{
-Cell[32624, 810, 1393, 24, 25, "Input",ExpressionUUID->"3c2d88fc-16a4-9648-b414-401d7d30c089",
+Cell[32723, 813, 1393, 24, 25, "Input",ExpressionUUID->"3c2d88fc-16a4-9648-b414-401d7d30c089",
  CellID->2282893],
-Cell[34020, 836, 3235, 70, 255, "Output",ExpressionUUID->"a4b4b6d1-2aa0-5749-aa91-cc41f531783d",
+Cell[34119, 839, 3235, 70, 255, "Output",ExpressionUUID->"a4b4b6d1-2aa0-5749-aa91-cc41f531783d",
  CellID->359213064]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[37292, 911, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"90e38493-127e-0943-b0dd-5f20d374f747",
+Cell[37391, 914, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"90e38493-127e-0943-b0dd-5f20d374f747",
  CellID->359821871],
-Cell[37537, 918, 286, 4, 24, "ExampleText",ExpressionUUID->"a56d4d89-8494-2b4c-9574-d6b8fda22be9",
+Cell[37636, 921, 286, 4, 24, "ExampleText",ExpressionUUID->"a56d4d89-8494-2b4c-9574-d6b8fda22be9",
  CellID->36408547],
-Cell[37826, 924, 608, 11, 25, "Input",ExpressionUUID->"b6ba46d0-ca10-4445-89df-535e94fa446a",
+Cell[37925, 927, 608, 11, 25, "Input",ExpressionUUID->"b6ba46d0-ca10-4445-89df-535e94fa446a",
  CellID->257600641],
 Cell[CellGroupData[{
-Cell[38459, 939, 1550, 29, 43, "Input",ExpressionUUID->"993568ac-0a3d-794c-b3c4-347fedccbdc2",
+Cell[38558, 942, 1550, 29, 43, "Input",ExpressionUUID->"993568ac-0a3d-794c-b3c4-347fedccbdc2",
  CellID->5704350],
-Cell[40012, 970, 3261, 70, 255, "Output",ExpressionUUID->"445bfc39-30bf-3b4f-9ef5-c47f2ba08cee",
+Cell[40111, 973, 3261, 70, 255, "Output",ExpressionUUID->"445bfc39-30bf-3b4f-9ef5-c47f2ba08cee",
  CellID->209734678]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[43322, 1046, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"d23bb43d-de1e-2141-b19a-fcc26220e5cf",
+Cell[43421, 1049, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"d23bb43d-de1e-2141-b19a-fcc26220e5cf",
  CellID->677196106],
-Cell[43567, 1053, 1272, 24, 62, "ExampleText",ExpressionUUID->"b39940f6-caca-c24e-a3cb-f0a92ec870c2",
+Cell[43666, 1056, 1270, 24, 62, "ExampleText",ExpressionUUID->"b39940f6-caca-c24e-a3cb-f0a92ec870c2",
  CellID->680708440],
-Cell[44842, 1079, 789, 14, 25, "Input",ExpressionUUID->"0634963b-2374-784f-895a-fc4179f77fea",
+Cell[44939, 1082, 789, 14, 25, "Input",ExpressionUUID->"0634963b-2374-784f-895a-fc4179f77fea",
  CellID->262417576],
-Cell[45634, 1095, 1268, 32, 78, "Input",ExpressionUUID->"5244972a-cb3b-2042-9daf-508c39bf118d",
+Cell[45731, 1098, 1268, 32, 78, "Input",ExpressionUUID->"5244972a-cb3b-2042-9daf-508c39bf118d",
  CellID->6127746],
-Cell[46905, 1129, 1021, 27, 78, "Input",ExpressionUUID->"7c31dba5-8134-0141-a1bc-a995f856c9f1",
+Cell[47002, 1132, 1021, 27, 78, "Input",ExpressionUUID->"7c31dba5-8134-0141-a1bc-a995f856c9f1",
  CellID->480595079],
 Cell[CellGroupData[{
-Cell[47951, 1160, 762, 18, 61, "Input",ExpressionUUID->"47ccee31-e999-4f4b-89f6-b9be1dab7766",
+Cell[48048, 1163, 762, 18, 61, "Input",ExpressionUUID->"47ccee31-e999-4f4b-89f6-b9be1dab7766",
  CellID->523535151],
-Cell[48716, 1180, 2712, 62, 255, "Output",ExpressionUUID->"158e5697-72c7-b546-b7a5-a4fe8fb1d25f",
+Cell[48813, 1183, 2712, 62, 255, "Output",ExpressionUUID->"158e5697-72c7-b546-b7a5-a4fe8fb1d25f",
  CellID->3419141]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[51477, 1248, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"420659d6-69c7-4b47-91d4-186ffaa4ea80",
+Cell[51574, 1251, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"420659d6-69c7-4b47-91d4-186ffaa4ea80",
  CellID->228953716],
-Cell[51722, 1255, 921, 17, 43, "ExampleText",ExpressionUUID->"73bd323e-2983-3346-a43a-e9815c20bad5",
+Cell[51819, 1258, 919, 17, 43, "ExampleText",ExpressionUUID->"73bd323e-2983-3346-a43a-e9815c20bad5",
  CellID->16699796],
-Cell[52646, 1274, 808, 14, 25, "Input",ExpressionUUID->"2c5d52cb-ae6f-0e45-a6e8-437f9ee96292",
+Cell[52741, 1277, 808, 14, 25, "Input",ExpressionUUID->"2c5d52cb-ae6f-0e45-a6e8-437f9ee96292",
  CellID->78835713],
-Cell[53457, 1290, 1179, 34, 141, "Input",ExpressionUUID->"b99c382e-9027-c64e-a409-16a28d4663c3",
+Cell[53552, 1293, 1179, 34, 141, "Input",ExpressionUUID->"b99c382e-9027-c64e-a409-16a28d4663c3",
  CellID->35451050]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[54673, 1329, 240, 5, 20, "ExampleDelimiter",ExpressionUUID->"05fc0fe4-70c9-6545-bdd9-4be99d3d1395",
+Cell[54768, 1332, 240, 5, 20, "ExampleDelimiter",ExpressionUUID->"05fc0fe4-70c9-6545-bdd9-4be99d3d1395",
  CellID->8004203],
-Cell[54916, 1336, 1064, 18, 77, "ExampleText",ExpressionUUID->"b14ef85e-62ef-be48-ab21-3877b825833e",
+Cell[55011, 1339, 1064, 18, 77, "ExampleText",ExpressionUUID->"b14ef85e-62ef-be48-ab21-3877b825833e",
  CellID->159657629],
-Cell[55983, 1356, 759, 15, 43, "Input",ExpressionUUID->"519611c8-75f2-f44c-9ec9-f910fc244df0",
+Cell[56078, 1359, 759, 15, 43, "Input",ExpressionUUID->"519611c8-75f2-f44c-9ec9-f910fc244df0",
  CellID->90165992],
 Cell[CellGroupData[{
-Cell[56767, 1375, 1520, 27, 43, "Input",ExpressionUUID->"6c596d02-90f5-d146-8be1-f3356df845bb",
+Cell[56862, 1378, 1520, 27, 43, "Input",ExpressionUUID->"6c596d02-90f5-d146-8be1-f3356df845bb",
  CellID->127721805],
-Cell[58290, 1404, 2800, 61, 224, "Output",ExpressionUUID->"4cf1493e-b455-c243-9db9-882346e7505a",
+Cell[58385, 1407, 2800, 61, 224, "Output",ExpressionUUID->"4cf1493e-b455-c243-9db9-882346e7505a",
  CellID->753181186]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[61139, 1471, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"95c5af2e-83e2-c049-ad95-26256e2f5154",
+Cell[61234, 1474, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"95c5af2e-83e2-c049-ad95-26256e2f5154",
  CellID->659468086],
-Cell[61384, 1478, 286, 4, 24, "ExampleText",ExpressionUUID->"987a05e3-a7ad-a544-b563-b693fa6f47d2",
+Cell[61479, 1481, 286, 4, 24, "ExampleText",ExpressionUUID->"987a05e3-a7ad-a544-b563-b693fa6f47d2",
  CellID->14052528],
-Cell[61673, 1484, 1115, 20, 43, "Input",ExpressionUUID->"87dcd6b9-c690-7e4a-b858-6909cb94d6c3",
+Cell[61768, 1487, 1115, 20, 43, "Input",ExpressionUUID->"87dcd6b9-c690-7e4a-b858-6909cb94d6c3",
  CellID->633400500],
 Cell[CellGroupData[{
-Cell[62813, 1508, 899, 22, 61, "Input",ExpressionUUID->"b90a0632-2b9c-434a-9376-b729453d40c5",
+Cell[62908, 1511, 899, 22, 61, "Input",ExpressionUUID->"b90a0632-2b9c-434a-9376-b729453d40c5",
  CellID->857781487],
-Cell[63715, 1532, 2491, 57, 224, "Output",ExpressionUUID->"8ced13b3-63d0-8d45-8dd7-723f3c271ea8",
+Cell[63810, 1535, 2491, 57, 224, "Output",ExpressionUUID->"8ced13b3-63d0-8d45-8dd7-723f3c271ea8",
  CellID->484200114]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[66255, 1595, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"10fb8044-d833-814d-8428-5bf3f7df9346",
+Cell[66350, 1598, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"10fb8044-d833-814d-8428-5bf3f7df9346",
  CellID->894366129],
-Cell[66500, 1602, 1254, 24, 62, "ExampleText",ExpressionUUID->"46243403-2377-eb49-9ebf-40693e875f3e",
+Cell[66595, 1605, 1252, 24, 62, "ExampleText",ExpressionUUID->"46243403-2377-eb49-9ebf-40693e875f3e",
  CellID->117730622],
-Cell[67757, 1628, 975, 18, 43, "Input",ExpressionUUID->"f3abe340-b842-8549-9bcc-35fdeae4c777",
+Cell[67850, 1631, 975, 18, 43, "Input",ExpressionUUID->"f3abe340-b842-8549-9bcc-35fdeae4c777",
  CellID->6395788],
-Cell[68735, 1648, 1265, 34, 78, "Input",ExpressionUUID->"756f6c00-4cbd-d740-b96b-27b4eb1883fb",
+Cell[68828, 1651, 1265, 34, 78, "Input",ExpressionUUID->"756f6c00-4cbd-d740-b96b-27b4eb1883fb",
  CellID->29715377],
-Cell[70003, 1684, 1139, 31, 78, "Input",ExpressionUUID->"2c21b325-a480-8d4f-b6bf-579aa3b2fe1b",
+Cell[70096, 1687, 1139, 31, 78, "Input",ExpressionUUID->"2c21b325-a480-8d4f-b6bf-579aa3b2fe1b",
  CellID->155041588],
 Cell[CellGroupData[{
-Cell[71167, 1719, 948, 22, 78, "Input",ExpressionUUID->"804403bc-dad2-0d43-bce2-6e1d2f45a281",
+Cell[71260, 1722, 948, 22, 78, "Input",ExpressionUUID->"804403bc-dad2-0d43-bce2-6e1d2f45a281",
  CellID->716857752],
-Cell[72118, 1743, 837, 22, 35, "Output",ExpressionUUID->"6bc136ed-d148-6949-a60c-bd3b6457236e",
+Cell[72211, 1746, 837, 22, 35, "Output",ExpressionUUID->"6bc136ed-d148-6949-a60c-bd3b6457236e",
  CellID->293199232]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[72992, 1770, 941, 21, 78, "Input",ExpressionUUID->"1e5b207d-23f8-d44c-afb3-9700f3986449",
+Cell[73085, 1773, 941, 21, 78, "Input",ExpressionUUID->"1e5b207d-23f8-d44c-afb3-9700f3986449",
  CellID->21816214],
-Cell[73936, 1793, 2251, 53, 224, "Output",ExpressionUUID->"24849a3f-e5da-3c44-8391-4c5752ad0833",
+Cell[74029, 1796, 2251, 53, 224, "Output",ExpressionUUID->"24849a3f-e5da-3c44-8391-4c5752ad0833",
  CellID->201795981]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[76236, 1852, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"b976ae74-6b35-2d45-98b1-6fe571c979a9",
+Cell[76329, 1855, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"b976ae74-6b35-2d45-98b1-6fe571c979a9",
  CellID->320137623],
-Cell[76481, 1859, 900, 17, 60, "ExampleText",ExpressionUUID->"c1cab9fe-eb87-d346-b31b-d6fb786d909c",
+Cell[76574, 1862, 900, 17, 60, "ExampleText",ExpressionUUID->"c1cab9fe-eb87-d346-b31b-d6fb786d909c",
  CellID->505606112],
-Cell[77384, 1878, 1008, 19, 43, "Input",ExpressionUUID->"47039000-32a1-5241-bd3a-50cef22daa71",
+Cell[77477, 1881, 1008, 19, 43, "Input",ExpressionUUID->"47039000-32a1-5241-bd3a-50cef22daa71",
  CellID->63697933],
-Cell[78395, 1899, 1767, 51, 224, "Input",ExpressionUUID->"6ece76b5-3a26-2f4e-a7d8-1d1826a648b3",
+Cell[78488, 1902, 1767, 51, 224, "Input",ExpressionUUID->"6ece76b5-3a26-2f4e-a7d8-1d1826a648b3",
  CellID->66478949]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[80211, 1956, 487, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"ff8d6064-9f88-a74d-a8fa-17fb12f09124",
+Cell[80304, 1959, 487, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"ff8d6064-9f88-a74d-a8fa-17fb12f09124",
  CellTags->"ExtendedExamples",
  CellID->326378688],
 Cell[CellGroupData[{
-Cell[80723, 1973, 241, 5, 35, "ExampleSection",ExpressionUUID->"ebb90dbe-6521-1749-85f4-6322f2026666",
+Cell[80816, 1976, 241, 5, 35, "ExampleSection",ExpressionUUID->"ebb90dbe-6521-1749-85f4-6322f2026666",
  CellID->452520281],
 Cell[CellGroupData[{
-Cell[80989, 1982, 182, 2, 24, "ExampleSubsection",ExpressionUUID->"334be610-900d-484f-bfe1-0437124d3430",
+Cell[81082, 1985, 182, 2, 24, "ExampleSubsection",ExpressionUUID->"334be610-900d-484f-bfe1-0437124d3430",
  CellID->198501545],
-Cell[81174, 1986, 1486, 22, 41, "ExampleText",ExpressionUUID->"91fe3dfc-3f15-2f41-b51e-992a9ff0e4f7",
+Cell[81267, 1989, 1486, 22, 41, "ExampleText",ExpressionUUID->"91fe3dfc-3f15-2f41-b51e-992a9ff0e4f7",
  CellID->723133349],
-Cell[82663, 2010, 783, 16, 43, "Input",ExpressionUUID->"fec21a5a-82ed-244f-97fc-0446c56b9ba0",
+Cell[82756, 2013, 783, 16, 43, "Input",ExpressionUUID->"fec21a5a-82ed-244f-97fc-0446c56b9ba0",
  CellID->407621152],
 Cell[CellGroupData[{
-Cell[83471, 2030, 656, 14, 25, "Input",ExpressionUUID->"c17fcdcd-8be0-214d-a8d2-54170e4bc6aa",
+Cell[83564, 2033, 656, 14, 25, "Input",ExpressionUUID->"c17fcdcd-8be0-214d-a8d2-54170e4bc6aa",
  CellID->244028921],
-Cell[84130, 2046, 2004, 58, 60, "Output",ExpressionUUID->"5d19e433-0e1c-6946-8021-a1acdcb9c8c6",
+Cell[84223, 2049, 2004, 58, 60, "Output",ExpressionUUID->"5d19e433-0e1c-6946-8021-a1acdcb9c8c6",
  CellID->21782229]
 }, Open  ]],
-Cell[86149, 2107, 1148, 27, 43, "Input",ExpressionUUID->"52baf7bd-c6f4-074e-9923-7c3ac2aac08e",
+Cell[86242, 2110, 1148, 27, 43, "Input",ExpressionUUID->"52baf7bd-c6f4-074e-9923-7c3ac2aac08e",
  CellID->197552022],
-Cell[87300, 2136, 1125, 23, 61, "Input",ExpressionUUID->"2da09c04-9266-9e4b-95aa-57649bab3d8a",
+Cell[87393, 2139, 1125, 23, 61, "Input",ExpressionUUID->"2da09c04-9266-9e4b-95aa-57649bab3d8a",
  CellID->233229007],
 Cell[CellGroupData[{
-Cell[88450, 2163, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"7fae9970-dc68-e245-9f46-8994f5ee5141",
+Cell[88543, 2166, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"7fae9970-dc68-e245-9f46-8994f5ee5141",
  CellID->631233377],
-Cell[88695, 2170, 982, 19, 60, "ExampleText",ExpressionUUID->"7d2792ed-a50c-dc42-b7cf-2eebc24cfb54",
+Cell[88788, 2173, 982, 19, 60, "ExampleText",ExpressionUUID->"7d2792ed-a50c-dc42-b7cf-2eebc24cfb54",
  CellID->293180495],
-Cell[89680, 2191, 1000, 21, 61, "Input",ExpressionUUID->"721a1c35-bfb5-0948-bee2-ceebc38af976",
+Cell[89773, 2194, 1000, 21, 61, "Input",ExpressionUUID->"721a1c35-bfb5-0948-bee2-ceebc38af976",
  CellID->272350353],
 Cell[CellGroupData[{
-Cell[90705, 2216, 560, 13, 25, "Input",ExpressionUUID->"f5eef431-c9c4-9e46-831b-8a35c8a2687d",
+Cell[90798, 2219, 560, 13, 25, "Input",ExpressionUUID->"f5eef431-c9c4-9e46-831b-8a35c8a2687d",
  CellID->160919502],
-Cell[91268, 2231, 1955, 58, 60, "Output",ExpressionUUID->"43fa3a2f-af06-4e4e-ad6f-5ece44240063",
+Cell[91361, 2234, 1955, 58, 60, "Output",ExpressionUUID->"43fa3a2f-af06-4e4e-ad6f-5ece44240063",
  CellID->6363342]
 }, Open  ]],
-Cell[93238, 2292, 1153, 27, 61, "Input",ExpressionUUID->"483ecfc5-709b-8146-8dd0-098ca38a4797",
+Cell[93331, 2295, 1153, 27, 61, "Input",ExpressionUUID->"483ecfc5-709b-8146-8dd0-098ca38a4797",
  CellID->102614535],
 Cell[CellGroupData[{
-Cell[94416, 2323, 1048, 23, 78, "Input",ExpressionUUID->"6fd7a3ab-5bae-dd4d-9f73-aef3ac7c4285",
+Cell[94509, 2326, 1048, 23, 78, "Input",ExpressionUUID->"6fd7a3ab-5bae-dd4d-9f73-aef3ac7c4285",
  CellID->128440207],
-Cell[95467, 2348, 1684, 44, 65, "Output",ExpressionUUID->"2b67ed65-a4c7-b040-9cd9-ec60e20e40d2",
+Cell[95560, 2351, 1684, 44, 65, "Output",ExpressionUUID->"2b67ed65-a4c7-b040-9cd9-ec60e20e40d2",
  CellID->90272515]
 }, Open  ]],
-Cell[97166, 2395, 1333, 26, 78, "Input",ExpressionUUID->"e9d4adb0-50e5-924f-8e3e-6b7e5ea18180",
+Cell[97259, 2398, 1333, 26, 78, "Input",ExpressionUUID->"e9d4adb0-50e5-924f-8e3e-6b7e5ea18180",
  CellID->293997694]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
-Cell[98538, 2426, 264, 5, 35, "ExampleSection",ExpressionUUID->"c3540bf7-4f16-c642-a969-4ed7094638b3",
+Cell[98631, 2429, 264, 5, 35, "ExampleSection",ExpressionUUID->"c3540bf7-4f16-c642-a969-4ed7094638b3",
  CellID->112538656],
 Cell[CellGroupData[{
-Cell[98827, 2435, 243, 5, 23, "ExampleSection",ExpressionUUID->"48157590-5f28-1c47-b312-e61b33053c9b",
+Cell[98920, 2438, 243, 5, 23, "ExampleSection",ExpressionUUID->"48157590-5f28-1c47-b312-e61b33053c9b",
  CellID->476698288],
 Cell[CellGroupData[{
-Cell[99095, 2444, 317, 6, 26, "ExampleSubsection",ExpressionUUID->"451e5695-341a-c546-a778-98db479c45a9",
+Cell[99188, 2447, 317, 6, 26, "ExampleSubsection",ExpressionUUID->"451e5695-341a-c546-a778-98db479c45a9",
  CellID->200887691],
-Cell[99415, 2452, 276, 5, 24, "ExampleText",ExpressionUUID->"ccdbb751-605f-4445-a640-a25ca2709b72",
+Cell[99508, 2455, 276, 5, 24, "ExampleText",ExpressionUUID->"ccdbb751-605f-4445-a640-a25ca2709b72",
  CellID->654805157],
 Cell[CellGroupData[{
-Cell[99716, 2461, 2403, 56, 166, "Input",ExpressionUUID->"5ae1ea12-31b6-a34d-b277-c8e18ed2b10b",
+Cell[99809, 2464, 2403, 56, 166, "Input",ExpressionUUID->"5ae1ea12-31b6-a34d-b277-c8e18ed2b10b",
  CellID->1148403],
-Cell[102122, 2519, 828, 17, 24, "Output",ExpressionUUID->"b1bc5949-29ec-f243-a200-dbc171b8e13c",
+Cell[102215, 2522, 828, 17, 24, "Output",ExpressionUUID->"b1bc5949-29ec-f243-a200-dbc171b8e13c",
  CellID->259030309]
 }, Open  ]],
-Cell[102965, 2539, 754, 15, 43, "ExampleText",ExpressionUUID->"cfb008d8-df29-0b45-8346-1d6404a3be97",
+Cell[103058, 2542, 754, 15, 43, "ExampleText",ExpressionUUID->"cfb008d8-df29-0b45-8346-1d6404a3be97",
  CellID->8011592],
-Cell[103722, 2556, 1370, 35, 45, "ExampleText",ExpressionUUID->"d4255562-a5f7-0f4a-af7f-f6cd3b92ca28",
+Cell[103815, 2559, 1370, 35, 45, "ExampleText",ExpressionUUID->"d4255562-a5f7-0f4a-af7f-f6cd3b92ca28",
  CellID->641512217]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[105129, 2596, 379, 7, 26, "ExampleSubsection",ExpressionUUID->"0e375e75-e1de-2c47-a1c0-f7a50b70a9ca",
+Cell[105222, 2599, 379, 7, 26, "ExampleSubsection",ExpressionUUID->"0e375e75-e1de-2c47-a1c0-f7a50b70a9ca",
  CellID->1036996805],
-Cell[105511, 2605, 1165, 29, 45, "ExampleText",ExpressionUUID->"558e6c8a-e58a-644a-88f3-9751d9d9522a",
+Cell[105604, 2608, 1165, 29, 45, "ExampleText",ExpressionUUID->"558e6c8a-e58a-644a-88f3-9751d9d9522a",
  CellID->1975506230],
-Cell[106679, 2636, 609, 11, 25, "Input",ExpressionUUID->"380a173b-5e67-7940-aa26-27c4fc9c0549",
+Cell[106772, 2639, 609, 11, 25, "Input",ExpressionUUID->"380a173b-5e67-7940-aa26-27c4fc9c0549",
  CellID->88541343],
 Cell[CellGroupData[{
-Cell[107313, 2651, 551, 12, 43, "Input",ExpressionUUID->"c017836a-e98a-5240-92f7-4b4bbddc50df",
+Cell[107406, 2654, 551, 12, 43, "Input",ExpressionUUID->"c017836a-e98a-5240-92f7-4b4bbddc50df",
  CellID->150127483],
-Cell[107867, 2665, 8498, 176, 53, "Output",ExpressionUUID->"5e3970ac-1c3d-1748-a69c-7f5e303c139e",
+Cell[107960, 2668, 8498, 176, 53, "Output",ExpressionUUID->"5e3970ac-1c3d-1748-a69c-7f5e303c139e",
  CellID->59323161]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[116402, 2846, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"d6917866-9ad9-5542-b0ed-240d114110d9",
+Cell[116495, 2849, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"d6917866-9ad9-5542-b0ed-240d114110d9",
  CellID->117913872],
-Cell[116647, 2853, 1220, 31, 45, "ExampleText",ExpressionUUID->"a7353174-267f-1347-adbc-3cd9cd8a782d",
+Cell[116740, 2856, 1220, 31, 45, "ExampleText",ExpressionUUID->"a7353174-267f-1347-adbc-3cd9cd8a782d",
  CellID->77617597],
-Cell[117870, 2886, 802, 16, 43, "Input",ExpressionUUID->"60dd7b09-9a16-3d48-b3ac-607ede755324",
+Cell[117963, 2889, 802, 16, 43, "Input",ExpressionUUID->"60dd7b09-9a16-3d48-b3ac-607ede755324",
  CellID->111045181],
 Cell[CellGroupData[{
-Cell[118697, 2906, 739, 16, 43, "Input",ExpressionUUID->"c74ad2dc-f06e-ac49-a1bd-83b77f67cac2",
+Cell[118790, 2909, 739, 16, 43, "Input",ExpressionUUID->"c74ad2dc-f06e-ac49-a1bd-83b77f67cac2",
  CellID->146570750],
-Cell[119439, 2924, 11367, 231, 53, "Output",ExpressionUUID->"9e022a2e-af24-9349-af27-5a344d8f2b85",
+Cell[119532, 2927, 11367, 231, 53, "Output",ExpressionUUID->"9e022a2e-af24-9349-af27-5a344d8f2b85",
  CellID->213302025]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
-Cell[130857, 3161, 248, 5, 35, "ExampleSection",ExpressionUUID->"206cc408-b3fa-7e40-9802-13411716b1ae",
+Cell[130950, 3164, 248, 5, 35, "ExampleSection",ExpressionUUID->"206cc408-b3fa-7e40-9802-13411716b1ae",
  CellID->466091341],
-Cell[131108, 3168, 258, 5, 23, "ExampleSection",ExpressionUUID->"4b5afd69-30b0-f549-a027-fda2dd3b83dc",
+Cell[CellGroupData[{
+Cell[131223, 3173, 258, 5, 23, "ExampleSection",ExpressionUUID->"4b5afd69-30b0-f549-a027-fda2dd3b83dc",
  CellID->113613961],
-Cell[131369, 3175, 251, 5, 23, "ExampleSection",ExpressionUUID->"4136bfca-ccae-4543-a89e-4ab36f7c6c92",
+Cell[CellGroupData[{
+Cell[131506, 3182, 767, 14, 28, "ExampleSubsection",ExpressionUUID->"998b3398-46d9-a441-93a4-7718f68d2e53",
+ CellID->296669070],
+Cell[132276, 3198, 1648, 25, 60, "ExampleText",ExpressionUUID->"7fae03ca-b5ec-1445-82d3-872a8360a200",
+ CellID->105689035],
+Cell[133927, 3225, 1543, 26, 41, "ExampleText",ExpressionUUID->"f0c703c0-675d-604c-b432-3e835efa8bb9",
+ CellID->709734105],
+Cell[135473, 3253, 1444, 28, 77, "ExampleText",ExpressionUUID->"e1347469-3698-e04d-b3cd-80a0661f52d5",
+ CellID->105347582],
+Cell[136920, 3283, 2507, 56, 159, "Input",ExpressionUUID->"6905becd-107c-0c40-a828-6d33a66536e2",
+ CellID->448289478],
+Cell[139430, 3341, 1062, 16, 58, "ExampleText",ExpressionUUID->"b900a028-a822-464c-b723-e8bfc1d1476e",
+ CellID->135010306],
+Cell[140495, 3359, 1301, 20, 58, "ExampleText",ExpressionUUID->"e541d214-04a7-bb47-af31-cfed6716a9fe",
+ CellID->359104851]
+}, Open  ]]
+}, Open  ]],
+Cell[141823, 3383, 251, 5, 35, "ExampleSection",ExpressionUUID->"4136bfca-ccae-4543-a89e-4ab36f7c6c92",
  CellID->594336563],
-Cell[131623, 3182, 256, 5, 23, "ExampleSection",ExpressionUUID->"b4c36045-96ed-834c-b920-7ee3972a6426",
+Cell[142077, 3390, 256, 5, 23, "ExampleSection",ExpressionUUID->"b4c36045-96ed-834c-b920-7ee3972a6426",
  CellID->763924802],
-Cell[131882, 3189, 248, 5, 23, "ExampleSection",ExpressionUUID->"06f28036-9ba1-174d-8b77-006aea84e464",
+Cell[142336, 3397, 248, 5, 23, "ExampleSection",ExpressionUUID->"06f28036-9ba1-174d-8b77-006aea84e464",
  CellID->76990128]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[132167, 3199, 109, 1, 72, "MetadataSection",ExpressionUUID->"01514484-f4d3-1046-88ee-2933f6f10c3c",
+Cell[142621, 3407, 109, 1, 72, "MetadataSection",ExpressionUUID->"01514484-f4d3-1046-88ee-2933f6f10c3c",
  CellID->42901253],
-Cell[132279, 3202, 473, 12, 26, "History",ExpressionUUID->"b24f5e18-8dc2-7c42-9e60-5eb0c5a2f27f",
+Cell[142733, 3410, 473, 12, 26, "History",ExpressionUUID->"b24f5e18-8dc2-7c42-9e60-5eb0c5a2f27f",
  CellID->969934],
 Cell[CellGroupData[{
-Cell[132777, 3218, 484, 13, 21, "CategorizationSection",ExpressionUUID->"54061416-e7a9-2f4a-be70-40d9b092ffe3",
+Cell[143231, 3426, 484, 13, 21, "CategorizationSection",ExpressionUUID->"54061416-e7a9-2f4a-be70-40d9b092ffe3",
  CellID->155892578],
-Cell[133264, 3233, 134, 2, 35, "Categorization",ExpressionUUID->"d38e05c9-59d0-a44b-ad25-467dfb60ec55",
+Cell[143718, 3441, 134, 2, 35, "Categorization",ExpressionUUID->"d38e05c9-59d0-a44b-ad25-467dfb60ec55",
  CellID->379313778],
-Cell[133401, 3237, 159, 2, 35, "Categorization",ExpressionUUID->"f8011cf6-d3ee-0149-a640-c6d486bf3660",
+Cell[143855, 3445, 159, 2, 35, "Categorization",ExpressionUUID->"f8011cf6-d3ee-0149-a640-c6d486bf3660",
  CellID->123752965],
-Cell[133563, 3241, 156, 2, 35, "Categorization",ExpressionUUID->"c2aaec4f-b9fb-7c4e-ac7d-63c6d46998c8",
+Cell[144017, 3449, 156, 2, 35, "Categorization",ExpressionUUID->"c2aaec4f-b9fb-7c4e-ac7d-63c6d46998c8",
  CellID->207073079],
-Cell[133722, 3245, 355, 7, 35, "Categorization",ExpressionUUID->"ffab9e82-e6de-3843-8507-c30bd9940ae6",
+Cell[144176, 3453, 355, 7, 35, "Categorization",ExpressionUUID->"ffab9e82-e6de-3843-8507-c30bd9940ae6",
  CellID->485781109]
 }, Closed]],
 Cell[CellGroupData[{
-Cell[134114, 3257, 109, 1, 21, "KeywordsSection",ExpressionUUID->"9948f113-07ed-b749-a7c7-02455661517b",
+Cell[144568, 3465, 109, 1, 21, "KeywordsSection",ExpressionUUID->"9948f113-07ed-b749-a7c7-02455661517b",
  CellID->55111812],
-Cell[134226, 3260, 98, 1, 70, "Keywords",ExpressionUUID->"13a5388c-964d-e948-88a8-f2bed6c00cae",
+Cell[144680, 3468, 98, 1, 70, "Keywords",ExpressionUUID->"13a5388c-964d-e948-88a8-f2bed6c00cae",
  CellID->78694749]
 }, Closed]],
 Cell[CellGroupData[{
-Cell[134361, 3266, 119, 1, 21, "TemplatesSection",ExpressionUUID->"6439de18-e57c-d548-bfa1-0f1cff993b74",
+Cell[144815, 3474, 119, 1, 21, "TemplatesSection",ExpressionUUID->"6439de18-e57c-d548-bfa1-0f1cff993b74",
  CellID->272215535],
-Cell[134483, 3269, 148, 2, 70, "Template",ExpressionUUID->"9a729cf7-1198-3c4b-b13a-f189371bdae6",
+Cell[144937, 3477, 148, 2, 70, "Template",ExpressionUUID->"9a729cf7-1198-3c4b-b13a-f189371bdae6",
  CellID->476199561],
-Cell[134634, 3273, 136, 2, 70, "Template",ExpressionUUID->"4d280ee1-1eaf-df45-bf64-789cd00641a2",
+Cell[145088, 3481, 136, 2, 70, "Template",ExpressionUUID->"4d280ee1-1eaf-df45-bf64-789cd00641a2",
  CellID->39443153],
-Cell[134773, 3277, 135, 2, 70, "Template",ExpressionUUID->"fe3509c5-ddbf-f84d-a38d-d2582ffef23c",
+Cell[145227, 3485, 135, 2, 70, "Template",ExpressionUUID->"fe3509c5-ddbf-f84d-a38d-d2582ffef23c",
  CellID->140411135],
-Cell[134911, 3281, 135, 2, 70, "Template",ExpressionUUID->"e2d612c8-c48e-c943-824b-d02a310bb682",
+Cell[145365, 3489, 135, 2, 70, "Template",ExpressionUUID->"e2d612c8-c48e-c943-824b-d02a310bb682",
  CellID->8216975]
 }, Closed]]
 }, Open  ]]

--- a/Paclet/Documentation/English/ReferencePages/Symbols/NonReciprocalTBHamiltonian.nb
+++ b/Paclet/Documentation/English/ReferencePages/Symbols/NonReciprocalTBHamiltonian.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[    185448,       4359]
-NotebookOptionsPosition[    166268,       3968]
-NotebookOutlinePosition[    167053,       3993]
-CellTagsIndexPosition[    166972,       3988]
+NotebookDataLength[    185657,       4363]
+NotebookOptionsPosition[    166476,       3972]
+NotebookOutlinePosition[    167261,       3997]
+CellTagsIndexPosition[    167180,       3992]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -371,14 +371,15 @@ Cell[BoxData[
         {
          RowBox[{
           SubscriptBox["b", "i"], "\[Rule]", 
-          SubscriptBox["b", "j"]}], 
+          SubscriptBox["a", "j"]}], 
          RowBox[{
           SubscriptBox["b", "i"], "\[Rule]", 
           SubscriptBox["b", "j"]}]}
        }], ")"}], "&"}]}], ";"}], " "}]], "Notes",
  CellChangeTimes->{{3.9594190921442356`*^9, 3.9594191869209785`*^9}, {
    3.9594199305607395`*^9, 3.959419942131056*^9}, 3.9594199844307747`*^9, {
-   3.959420111086876*^9, 3.9594201114812164`*^9}, 3.959420152732893*^9},
+   3.959420111086876*^9, 3.9594201114812164`*^9}, 3.959420152732893*^9, {
+   3.9596604831338425`*^9, 3.959660483318983*^9}},
  CellID->207376718,ExpressionUUID->"9d096777-ed38-fa42-a3f0-204ba6b6a912"],
 
 Cell[TextData[Cell[BoxData[
@@ -396,7 +397,7 @@ Cell[TextData[Cell[BoxData[
        {
         RowBox[{
          SubscriptBox["b", "i"], "\[LeftArrow]", 
-         SubscriptBox["b", "j"]}], 
+         SubscriptBox["a", "j"]}], 
         RowBox[{
          SubscriptBox["b", "i"], "\[LeftArrow]", 
          SubscriptBox["b", "j"]}]}
@@ -405,7 +406,8 @@ Cell[TextData[Cell[BoxData[
   3.9594199305607395`*^9, 
   3.959419942131056*^9}},ExpressionUUID->"6a2b9153-008e-0c44-bc72-\
 a9eec9fdfb31"]], "Notes",
- CellChangeTimes->{{3.959420522251034*^9, 3.9594205393492985`*^9}},
+ CellChangeTimes->{{3.959420522251034*^9, 3.9594205393492985`*^9}, {
+  3.959660479613844*^9, 3.959660481062271*^9}},
  CellID->396819643,ExpressionUUID->"ad6e1f75-94fc-a24f-8210-98a92e4ba89d"],
 
 Cell[TextData[{
@@ -646,7 +648,7 @@ Cell[BoxData[
         {
          RowBox[{
           SubscriptBox["b", "i"], "\[Rule]", 
-          SubscriptBox["b", "j"]}], 
+          SubscriptBox["a", "j"]}], 
          RowBox[{
           SubscriptBox["b", "i"], "\[Rule]", 
           SubscriptBox["b", "j"]}]}
@@ -654,7 +656,8 @@ Cell[BoxData[
  CellChangeTimes->{{3.9594190921442356`*^9, 3.9594191869209785`*^9}, {
    3.9594199305607395`*^9, 3.959419942131056*^9}, 3.9594199844307747`*^9, {
    3.959420111086876*^9, 3.9594201114812164`*^9}, 3.959420152732893*^9, {
-   3.9594227010783463`*^9, 3.959422701282736*^9}},
+   3.9594227010783463`*^9, 3.959422701282736*^9}, {3.9596604873247757`*^9, 
+   3.9596604899853687`*^9}},
  CellID->367081081,ExpressionUUID->"c8bb76f0-24c8-404a-81f9-e75585047e2e"],
 
 Cell[TextData[Cell[BoxData[
@@ -672,7 +675,7 @@ Cell[TextData[Cell[BoxData[
        {
         RowBox[{
          SubscriptBox["b", "i"], "\[LeftArrow]", 
-         SubscriptBox["b", "j"]}], 
+         SubscriptBox["a", "j"]}], 
         RowBox[{
          SubscriptBox["b", "i"], "\[LeftArrow]", 
          SubscriptBox["b", "j"]}]}
@@ -682,7 +685,8 @@ Cell[TextData[Cell[BoxData[
   3.959419942131056*^9}},ExpressionUUID->"51d8c5b4-430c-7c43-bcd8-\
 672281462a54"]], "Notes",
  CellChangeTimes->{{3.959420522251034*^9, 3.9594205393492985`*^9}, {
-  3.9594227034669304`*^9, 3.959422703616144*^9}},
+  3.9594227034669304`*^9, 3.959422703616144*^9}, {3.9596604921122074`*^9, 
+  3.9596604922593822`*^9}},
  CellID->285432429,ExpressionUUID->"8d2c174b-0d89-2f4d-93e6-d4ab5843940d"],
 
 Cell[TextData[{
@@ -907,10 +911,10 @@ NonReciprocalAbelianBlochHamiltonian"]], "InlineSeeAlsoFunction",
     "429010f2-dc11-0d47-84f1-dce239246c39"], 
    DynamicModuleBox[{$CellContext`nbobj$$ = NotebookObject[
     "ca524783-33ba-4436-a7c7-e9b68abdb844", 
-     "fa97ef78-ffa8-c645-8af3-c151b65e2622"], $CellContext`cellobj$$ = 
+     "7cc12531-55b3-7145-b13a-bc1f8f24d208"], $CellContext`cellobj$$ = 
     CellObject[
     "33b21f5c-9fe9-244c-ae30-addab55a5b8a", 
-     "0f82979c-74b3-324a-95ed-8e25a3306ae7"]}, 
+     "29859f5c-b99e-ef43-a6c6-841b5cb3a2b5"]}, 
     TemplateBox[{
       GraphicsBox[{{
          Thickness[0.06], 
@@ -3980,14 +3984,14 @@ ExpressionUUID->"ca524783-33ba-4436-a7c7-e9b68abdb844"
 (*CellTagsOutline
 CellTagsIndex->{
  "ExtendedExamples"->{
-  Cell[89198, 2186, 487, 13, 56, "ExtendedExamplesSection",ExpressionUUID->"ff8d6064-9f88-a74d-a8fa-17fb12f09124",
+  Cell[89406, 2190, 487, 13, 56, "ExtendedExamplesSection",ExpressionUUID->"ff8d6064-9f88-a74d-a8fa-17fb12f09124",
    CellTags->"ExtendedExamples",
    CellID->326378688]}
  }
 *)
 (*CellTagsIndex
 CellTagsIndex->{
- {"ExtendedExamples", 166777, 3981}
+ {"ExtendedExamples", 166985, 3985}
  }
 *)
 (*NotebookFileOutline
@@ -4005,359 +4009,359 @@ Cell[11254, 268, 1511, 37, 87, "Notes",ExpressionUUID->"916d2e20-f426-4271-9d7c-
  CellID->122405462],
 Cell[12768, 307, 2187, 48, 156, "Notes",ExpressionUUID->"9e832cf1-cb3b-944b-87d7-d59ba8c6c42e",
  CellID->311370265],
-Cell[14958, 357, 882, 24, 41, "Notes",ExpressionUUID->"9d096777-ed38-fa42-a3f0-204ba6b6a912",
+Cell[14958, 357, 934, 25, 41, "Notes",ExpressionUUID->"9d096777-ed38-fa42-a3f0-204ba6b6a912",
  CellID->207376718],
-Cell[15843, 383, 910, 25, 41, "Notes",ExpressionUUID->"ad6e1f75-94fc-a24f-8210-98a92e4ba89d",
+Cell[15895, 384, 959, 26, 41, "Notes",ExpressionUUID->"ad6e1f75-94fc-a24f-8210-98a92e4ba89d",
  CellID->396819643],
-Cell[16756, 410, 1608, 35, 46, "Notes",ExpressionUUID->"61fdac31-46a3-0740-85a1-4f9fb65c236b",
+Cell[16857, 412, 1608, 35, 46, "Notes",ExpressionUUID->"61fdac31-46a3-0740-85a1-4f9fb65c236b",
  CellID->372301786],
-Cell[18367, 447, 1485, 33, 46, "Notes",ExpressionUUID->"29c3eeb1-4bd4-fb41-8a8e-6a5cf6292032",
+Cell[18468, 449, 1485, 33, 46, "Notes",ExpressionUUID->"29c3eeb1-4bd4-fb41-8a8e-6a5cf6292032",
  CellID->96192577],
-Cell[19855, 482, 2213, 50, 87, "Notes",ExpressionUUID->"6ee1f639-78fc-9443-9db0-28a0b4f196ff",
+Cell[19956, 484, 2213, 50, 87, "Notes",ExpressionUUID->"6ee1f639-78fc-9443-9db0-28a0b4f196ff",
  CellID->258865958],
-Cell[22071, 534, 1675, 43, 87, "Notes",ExpressionUUID->"befd335a-f1a3-a742-adb8-bd6148e17917",
+Cell[22172, 536, 1675, 43, 87, "Notes",ExpressionUUID->"befd335a-f1a3-a742-adb8-bd6148e17917",
  CellID->978527526],
-Cell[23749, 579, 2394, 51, 159, "Notes",ExpressionUUID->"14065189-ed9c-344a-85a6-123ab8a4107c",
+Cell[23850, 581, 2394, 51, 159, "Notes",ExpressionUUID->"14065189-ed9c-344a-85a6-123ab8a4107c",
  CellID->49378578],
-Cell[26146, 632, 936, 25, 41, "Notes",ExpressionUUID->"c8bb76f0-24c8-404a-81f9-e75585047e2e",
+Cell[26247, 634, 990, 26, 41, "Notes",ExpressionUUID->"c8bb76f0-24c8-404a-81f9-e75585047e2e",
  CellID->367081081],
-Cell[27085, 659, 963, 26, 41, "Notes",ExpressionUUID->"8d2c174b-0d89-2f4d-93e6-d4ab5843940d",
+Cell[27240, 662, 1016, 27, 41, "Notes",ExpressionUUID->"8d2c174b-0d89-2f4d-93e6-d4ab5843940d",
  CellID->285432429],
-Cell[28051, 687, 601, 14, 43, "Notes",ExpressionUUID->"d173a5c5-bc1e-3d47-a90c-5521c018062a",
+Cell[28259, 691, 601, 14, 43, "Notes",ExpressionUUID->"d173a5c5-bc1e-3d47-a90c-5521c018062a",
  CellID->602129332],
-Cell[28655, 703, 223, 3, 26, "Notes",ExpressionUUID->"1c7289b5-700a-c54e-9a07-7e04882eec7b",
+Cell[28863, 707, 223, 3, 26, "Notes",ExpressionUUID->"1c7289b5-700a-c54e-9a07-7e04882eec7b",
  CellID->444168746],
-Cell[28881, 708, 1770, 41, 87, "3ColumnTableMod",ExpressionUUID->"ef297d37-914b-8f42-bbda-f7d0f0fab73c",
+Cell[29089, 712, 1770, 41, 87, "3ColumnTableMod",ExpressionUUID->"ef297d37-914b-8f42-bbda-f7d0f0fab73c",
  CellID->65923218]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[30688, 754, 435, 12, 39, "TechNotesSection",ExpressionUUID->"0fea9c94-dcc9-4460-b773-0032ab8ec549",
+Cell[30896, 758, 435, 12, 39, "TechNotesSection",ExpressionUUID->"0fea9c94-dcc9-4460-b773-0032ab8ec549",
  CellID->995312194],
-Cell[31126, 768, 265, 6, 17, "Tutorials",ExpressionUUID->"1928c8e7-a68c-46a0-8cba-0ffff1419b9e",
+Cell[31334, 772, 265, 6, 17, "Tutorials",ExpressionUUID->"1928c8e7-a68c-46a0-8cba-0ffff1419b9e",
  CellID->151400]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[31428, 779, 472, 13, 38, "RelatedLinksSection",ExpressionUUID->"fecb14cf-25fa-4a0c-9894-8ca8438f0be1",
+Cell[31636, 783, 472, 13, 38, "RelatedLinksSection",ExpressionUUID->"fecb14cf-25fa-4a0c-9894-8ca8438f0be1",
  CellID->202509145],
-Cell[31903, 794, 103, 1, 17, "RelatedLinks",ExpressionUUID->"79cdcc1a-2b16-4dc9-9e2d-fc7a3173b09d",
+Cell[32111, 798, 103, 1, 17, "RelatedLinks",ExpressionUUID->"79cdcc1a-2b16-4dc9-9e2d-fc7a3173b09d",
  CellID->144199850]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[32043, 800, 458, 13, 38, "SeeAlsoSection",ExpressionUUID->"8abec620-8af0-574a-9875-b24068b2beef",
+Cell[32251, 804, 458, 13, 38, "SeeAlsoSection",ExpressionUUID->"8abec620-8af0-574a-9875-b24068b2beef",
  CellID->223461721],
-Cell[32504, 815, 5548, 130, 65, "SeeAlso",ExpressionUUID->"1af84081-07d0-944f-aa97-505b313e997c",
+Cell[32712, 819, 5548, 130, 65, "SeeAlso",ExpressionUUID->"1af84081-07d0-944f-aa97-505b313e997c",
  CellID->381155944]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[38089, 950, 182, 2, 37, "MoreAboutSection",ExpressionUUID->"628c56fb-2a64-454a-afda-0c72e8b98f07",
+Cell[38297, 954, 182, 2, 37, "MoreAboutSection",ExpressionUUID->"628c56fb-2a64-454a-afda-0c72e8b98f07",
  CellID->31221473],
-Cell[38274, 954, 281, 6, 17, "MoreAbout",ExpressionUUID->"f716947c-4c12-47a4-9cff-f2a24ce82555",
+Cell[38482, 958, 281, 6, 17, "MoreAbout",ExpressionUUID->"f716947c-4c12-47a4-9cff-f2a24ce82555",
  CellID->542581366]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[38592, 965, 530, 14, 68, "ExamplesInitializationSection",ExpressionUUID->"d27dce01-6ac7-4a45-a9d6-0701f911e181",
+Cell[38800, 969, 530, 14, 68, "ExamplesInitializationSection",ExpressionUUID->"d27dce01-6ac7-4a45-a9d6-0701f911e181",
  CellID->428868112],
-Cell[39125, 981, 306, 5, 45, "ExampleInitialization",ExpressionUUID->"b9b2fab4-94b0-40ca-9b3a-2f0308baac5d",
+Cell[39333, 985, 306, 5, 45, "ExampleInitialization",ExpressionUUID->"b9b2fab4-94b0-40ca-9b3a-2f0308baac5d",
  CellID->127019986]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[39468, 991, 441, 12, 69, "PrimaryExamplesSection",ExpressionUUID->"898c9691-0437-2b4f-911a-086c5248b0cc",
+Cell[39676, 995, 441, 12, 69, "PrimaryExamplesSection",ExpressionUUID->"898c9691-0437-2b4f-911a-086c5248b0cc",
  CellID->11026314],
-Cell[39912, 1005, 1069, 18, 71, "ExampleText",ExpressionUUID->"665d84cd-aea7-8c4c-8c5b-c3de1f16dc2a",
+Cell[40120, 1009, 1069, 18, 71, "ExampleText",ExpressionUUID->"665d84cd-aea7-8c4c-8c5b-c3de1f16dc2a",
  CellID->82755364],
-Cell[40984, 1025, 608, 11, 25, "Input",ExpressionUUID->"cb9530ef-450c-3c4d-b5fb-7739129fba2c",
+Cell[41192, 1029, 608, 11, 25, "Input",ExpressionUUID->"cb9530ef-450c-3c4d-b5fb-7739129fba2c",
  CellID->642833953],
 Cell[CellGroupData[{
-Cell[41617, 1040, 1393, 24, 25, "Input",ExpressionUUID->"3c2d88fc-16a4-9648-b414-401d7d30c089",
+Cell[41825, 1044, 1393, 24, 25, "Input",ExpressionUUID->"3c2d88fc-16a4-9648-b414-401d7d30c089",
  CellID->2282893],
-Cell[43013, 1066, 3235, 70, 253, "Output",ExpressionUUID->"a4b4b6d1-2aa0-5749-aa91-cc41f531783d",
+Cell[43221, 1070, 3235, 70, 253, "Output",ExpressionUUID->"a4b4b6d1-2aa0-5749-aa91-cc41f531783d",
  CellID->359213064]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[46285, 1141, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"90e38493-127e-0943-b0dd-5f20d374f747",
+Cell[46493, 1145, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"90e38493-127e-0943-b0dd-5f20d374f747",
  CellID->359821871],
-Cell[46530, 1148, 286, 4, 23, "ExampleText",ExpressionUUID->"a56d4d89-8494-2b4c-9574-d6b8fda22be9",
+Cell[46738, 1152, 286, 4, 23, "ExampleText",ExpressionUUID->"a56d4d89-8494-2b4c-9574-d6b8fda22be9",
  CellID->36408547],
-Cell[46819, 1154, 608, 11, 25, "Input",ExpressionUUID->"b6ba46d0-ca10-4445-89df-535e94fa446a",
+Cell[47027, 1158, 608, 11, 25, "Input",ExpressionUUID->"b6ba46d0-ca10-4445-89df-535e94fa446a",
  CellID->257600641],
 Cell[CellGroupData[{
-Cell[47452, 1169, 1550, 29, 42, "Input",ExpressionUUID->"993568ac-0a3d-794c-b3c4-347fedccbdc2",
+Cell[47660, 1173, 1550, 29, 42, "Input",ExpressionUUID->"993568ac-0a3d-794c-b3c4-347fedccbdc2",
  CellID->5704350],
-Cell[49005, 1200, 3261, 70, 253, "Output",ExpressionUUID->"445bfc39-30bf-3b4f-9ef5-c47f2ba08cee",
+Cell[49213, 1204, 3261, 70, 253, "Output",ExpressionUUID->"445bfc39-30bf-3b4f-9ef5-c47f2ba08cee",
  CellID->209734678]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[52315, 1276, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"d23bb43d-de1e-2141-b19a-fcc26220e5cf",
+Cell[52523, 1280, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"d23bb43d-de1e-2141-b19a-fcc26220e5cf",
  CellID->677196106],
-Cell[52560, 1283, 1270, 24, 55, "ExampleText",ExpressionUUID->"b39940f6-caca-c24e-a3cb-f0a92ec870c2",
+Cell[52768, 1287, 1270, 24, 55, "ExampleText",ExpressionUUID->"b39940f6-caca-c24e-a3cb-f0a92ec870c2",
  CellID->680708440],
-Cell[53833, 1309, 789, 14, 25, "Input",ExpressionUUID->"0634963b-2374-784f-895a-fc4179f77fea",
+Cell[54041, 1313, 789, 14, 25, "Input",ExpressionUUID->"0634963b-2374-784f-895a-fc4179f77fea",
  CellID->262417576],
-Cell[54625, 1325, 1268, 32, 77, "Input",ExpressionUUID->"5244972a-cb3b-2042-9daf-508c39bf118d",
+Cell[54833, 1329, 1268, 32, 77, "Input",ExpressionUUID->"5244972a-cb3b-2042-9daf-508c39bf118d",
  CellID->6127746],
-Cell[55896, 1359, 1021, 27, 77, "Input",ExpressionUUID->"7c31dba5-8134-0141-a1bc-a995f856c9f1",
+Cell[56104, 1363, 1021, 27, 77, "Input",ExpressionUUID->"7c31dba5-8134-0141-a1bc-a995f856c9f1",
  CellID->480595079],
 Cell[CellGroupData[{
-Cell[56942, 1390, 762, 18, 60, "Input",ExpressionUUID->"47ccee31-e999-4f4b-89f6-b9be1dab7766",
+Cell[57150, 1394, 762, 18, 60, "Input",ExpressionUUID->"47ccee31-e999-4f4b-89f6-b9be1dab7766",
  CellID->523535151],
-Cell[57707, 1410, 2712, 62, 253, "Output",ExpressionUUID->"158e5697-72c7-b546-b7a5-a4fe8fb1d25f",
+Cell[57915, 1414, 2712, 62, 253, "Output",ExpressionUUID->"158e5697-72c7-b546-b7a5-a4fe8fb1d25f",
  CellID->3419141]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[60468, 1478, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"420659d6-69c7-4b47-91d4-186ffaa4ea80",
+Cell[60676, 1482, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"420659d6-69c7-4b47-91d4-186ffaa4ea80",
  CellID->228953716],
-Cell[60713, 1485, 919, 17, 39, "ExampleText",ExpressionUUID->"73bd323e-2983-3346-a43a-e9815c20bad5",
+Cell[60921, 1489, 919, 17, 39, "ExampleText",ExpressionUUID->"73bd323e-2983-3346-a43a-e9815c20bad5",
  CellID->16699796],
-Cell[61635, 1504, 808, 14, 25, "Input",ExpressionUUID->"2c5d52cb-ae6f-0e45-a6e8-437f9ee96292",
+Cell[61843, 1508, 808, 14, 25, "Input",ExpressionUUID->"2c5d52cb-ae6f-0e45-a6e8-437f9ee96292",
  CellID->78835713],
-Cell[62446, 1520, 1179, 34, 139, "Input",ExpressionUUID->"b99c382e-9027-c64e-a409-16a28d4663c3",
+Cell[62654, 1524, 1179, 34, 139, "Input",ExpressionUUID->"b99c382e-9027-c64e-a409-16a28d4663c3",
  CellID->35451050]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[63662, 1559, 240, 5, 16, "ExampleDelimiter",ExpressionUUID->"05fc0fe4-70c9-6545-bdd9-4be99d3d1395",
+Cell[63870, 1563, 240, 5, 16, "ExampleDelimiter",ExpressionUUID->"05fc0fe4-70c9-6545-bdd9-4be99d3d1395",
  CellID->8004203],
-Cell[63905, 1566, 1064, 18, 71, "ExampleText",ExpressionUUID->"b14ef85e-62ef-be48-ab21-3877b825833e",
+Cell[64113, 1570, 1064, 18, 71, "ExampleText",ExpressionUUID->"b14ef85e-62ef-be48-ab21-3877b825833e",
  CellID->159657629],
-Cell[64972, 1586, 759, 15, 42, "Input",ExpressionUUID->"519611c8-75f2-f44c-9ec9-f910fc244df0",
+Cell[65180, 1590, 759, 15, 42, "Input",ExpressionUUID->"519611c8-75f2-f44c-9ec9-f910fc244df0",
  CellID->90165992],
 Cell[CellGroupData[{
-Cell[65756, 1605, 1520, 27, 42, "Input",ExpressionUUID->"6c596d02-90f5-d146-8be1-f3356df845bb",
+Cell[65964, 1609, 1520, 27, 42, "Input",ExpressionUUID->"6c596d02-90f5-d146-8be1-f3356df845bb",
  CellID->127721805],
-Cell[67279, 1634, 2800, 61, 222, "Output",ExpressionUUID->"4cf1493e-b455-c243-9db9-882346e7505a",
+Cell[67487, 1638, 2800, 61, 222, "Output",ExpressionUUID->"4cf1493e-b455-c243-9db9-882346e7505a",
  CellID->753181186]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[70128, 1701, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"95c5af2e-83e2-c049-ad95-26256e2f5154",
+Cell[70336, 1705, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"95c5af2e-83e2-c049-ad95-26256e2f5154",
  CellID->659468086],
-Cell[70373, 1708, 286, 4, 23, "ExampleText",ExpressionUUID->"987a05e3-a7ad-a544-b563-b693fa6f47d2",
+Cell[70581, 1712, 286, 4, 23, "ExampleText",ExpressionUUID->"987a05e3-a7ad-a544-b563-b693fa6f47d2",
  CellID->14052528],
-Cell[70662, 1714, 1115, 20, 42, "Input",ExpressionUUID->"87dcd6b9-c690-7e4a-b858-6909cb94d6c3",
+Cell[70870, 1718, 1115, 20, 42, "Input",ExpressionUUID->"87dcd6b9-c690-7e4a-b858-6909cb94d6c3",
  CellID->633400500],
 Cell[CellGroupData[{
-Cell[71802, 1738, 899, 22, 60, "Input",ExpressionUUID->"b90a0632-2b9c-434a-9376-b729453d40c5",
+Cell[72010, 1742, 899, 22, 60, "Input",ExpressionUUID->"b90a0632-2b9c-434a-9376-b729453d40c5",
  CellID->857781487],
-Cell[72704, 1762, 2491, 57, 222, "Output",ExpressionUUID->"8ced13b3-63d0-8d45-8dd7-723f3c271ea8",
+Cell[72912, 1766, 2491, 57, 222, "Output",ExpressionUUID->"8ced13b3-63d0-8d45-8dd7-723f3c271ea8",
  CellID->484200114]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[75244, 1825, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"10fb8044-d833-814d-8428-5bf3f7df9346",
+Cell[75452, 1829, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"10fb8044-d833-814d-8428-5bf3f7df9346",
  CellID->894366129],
-Cell[75489, 1832, 1252, 24, 55, "ExampleText",ExpressionUUID->"46243403-2377-eb49-9ebf-40693e875f3e",
+Cell[75697, 1836, 1252, 24, 55, "ExampleText",ExpressionUUID->"46243403-2377-eb49-9ebf-40693e875f3e",
  CellID->117730622],
-Cell[76744, 1858, 975, 18, 42, "Input",ExpressionUUID->"f3abe340-b842-8549-9bcc-35fdeae4c777",
+Cell[76952, 1862, 975, 18, 42, "Input",ExpressionUUID->"f3abe340-b842-8549-9bcc-35fdeae4c777",
  CellID->6395788],
-Cell[77722, 1878, 1265, 34, 77, "Input",ExpressionUUID->"756f6c00-4cbd-d740-b96b-27b4eb1883fb",
+Cell[77930, 1882, 1265, 34, 77, "Input",ExpressionUUID->"756f6c00-4cbd-d740-b96b-27b4eb1883fb",
  CellID->29715377],
-Cell[78990, 1914, 1139, 31, 77, "Input",ExpressionUUID->"2c21b325-a480-8d4f-b6bf-579aa3b2fe1b",
+Cell[79198, 1918, 1139, 31, 77, "Input",ExpressionUUID->"2c21b325-a480-8d4f-b6bf-579aa3b2fe1b",
  CellID->155041588],
 Cell[CellGroupData[{
-Cell[80154, 1949, 948, 22, 77, "Input",ExpressionUUID->"804403bc-dad2-0d43-bce2-6e1d2f45a281",
+Cell[80362, 1953, 948, 22, 77, "Input",ExpressionUUID->"804403bc-dad2-0d43-bce2-6e1d2f45a281",
  CellID->716857752],
-Cell[81105, 1973, 837, 22, 33, "Output",ExpressionUUID->"6bc136ed-d148-6949-a60c-bd3b6457236e",
+Cell[81313, 1977, 837, 22, 33, "Output",ExpressionUUID->"6bc136ed-d148-6949-a60c-bd3b6457236e",
  CellID->293199232]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[81979, 2000, 941, 21, 77, "Input",ExpressionUUID->"1e5b207d-23f8-d44c-afb3-9700f3986449",
+Cell[82187, 2004, 941, 21, 77, "Input",ExpressionUUID->"1e5b207d-23f8-d44c-afb3-9700f3986449",
  CellID->21816214],
-Cell[82923, 2023, 2251, 53, 222, "Output",ExpressionUUID->"24849a3f-e5da-3c44-8391-4c5752ad0833",
+Cell[83131, 2027, 2251, 53, 222, "Output",ExpressionUUID->"24849a3f-e5da-3c44-8391-4c5752ad0833",
  CellID->201795981]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[85223, 2082, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"b976ae74-6b35-2d45-98b1-6fe571c979a9",
+Cell[85431, 2086, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"b976ae74-6b35-2d45-98b1-6fe571c979a9",
  CellID->320137623],
-Cell[85468, 2089, 900, 17, 55, "ExampleText",ExpressionUUID->"c1cab9fe-eb87-d346-b31b-d6fb786d909c",
+Cell[85676, 2093, 900, 17, 55, "ExampleText",ExpressionUUID->"c1cab9fe-eb87-d346-b31b-d6fb786d909c",
  CellID->505606112],
-Cell[86371, 2108, 1008, 19, 42, "Input",ExpressionUUID->"47039000-32a1-5241-bd3a-50cef22daa71",
+Cell[86579, 2112, 1008, 19, 42, "Input",ExpressionUUID->"47039000-32a1-5241-bd3a-50cef22daa71",
  CellID->63697933],
-Cell[87382, 2129, 1767, 51, 222, "Input",ExpressionUUID->"6ece76b5-3a26-2f4e-a7d8-1d1826a648b3",
+Cell[87590, 2133, 1767, 51, 222, "Input",ExpressionUUID->"6ece76b5-3a26-2f4e-a7d8-1d1826a648b3",
  CellID->66478949]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[89198, 2186, 487, 13, 56, "ExtendedExamplesSection",ExpressionUUID->"ff8d6064-9f88-a74d-a8fa-17fb12f09124",
+Cell[89406, 2190, 487, 13, 56, "ExtendedExamplesSection",ExpressionUUID->"ff8d6064-9f88-a74d-a8fa-17fb12f09124",
  CellTags->"ExtendedExamples",
  CellID->326378688],
 Cell[CellGroupData[{
-Cell[89710, 2203, 241, 5, 32, "ExampleSection",ExpressionUUID->"ebb90dbe-6521-1749-85f4-6322f2026666",
+Cell[89918, 2207, 241, 5, 32, "ExampleSection",ExpressionUUID->"ebb90dbe-6521-1749-85f4-6322f2026666",
  CellID->452520281],
 Cell[CellGroupData[{
-Cell[89976, 2212, 182, 2, 23, "ExampleSubsection",ExpressionUUID->"334be610-900d-484f-bfe1-0437124d3430",
+Cell[90184, 2216, 182, 2, 23, "ExampleSubsection",ExpressionUUID->"334be610-900d-484f-bfe1-0437124d3430",
  CellID->198501545],
-Cell[90161, 2216, 1486, 22, 39, "ExampleText",ExpressionUUID->"91fe3dfc-3f15-2f41-b51e-992a9ff0e4f7",
+Cell[90369, 2220, 1486, 22, 39, "ExampleText",ExpressionUUID->"91fe3dfc-3f15-2f41-b51e-992a9ff0e4f7",
  CellID->723133349],
-Cell[91650, 2240, 783, 16, 42, "Input",ExpressionUUID->"fec21a5a-82ed-244f-97fc-0446c56b9ba0",
+Cell[91858, 2244, 783, 16, 42, "Input",ExpressionUUID->"fec21a5a-82ed-244f-97fc-0446c56b9ba0",
  CellID->407621152],
 Cell[CellGroupData[{
-Cell[92458, 2260, 656, 14, 25, "Input",ExpressionUUID->"c17fcdcd-8be0-214d-a8d2-54170e4bc6aa",
+Cell[92666, 2264, 656, 14, 25, "Input",ExpressionUUID->"c17fcdcd-8be0-214d-a8d2-54170e4bc6aa",
  CellID->244028921],
-Cell[93117, 2276, 2004, 58, 59, "Output",ExpressionUUID->"5d19e433-0e1c-6946-8021-a1acdcb9c8c6",
+Cell[93325, 2280, 2004, 58, 59, "Output",ExpressionUUID->"5d19e433-0e1c-6946-8021-a1acdcb9c8c6",
  CellID->21782229]
 }, Open  ]],
-Cell[95136, 2337, 1148, 27, 42, "Input",ExpressionUUID->"52baf7bd-c6f4-074e-9923-7c3ac2aac08e",
+Cell[95344, 2341, 1148, 27, 42, "Input",ExpressionUUID->"52baf7bd-c6f4-074e-9923-7c3ac2aac08e",
  CellID->197552022],
-Cell[96287, 2366, 1125, 23, 60, "Input",ExpressionUUID->"2da09c04-9266-9e4b-95aa-57649bab3d8a",
+Cell[96495, 2370, 1125, 23, 60, "Input",ExpressionUUID->"2da09c04-9266-9e4b-95aa-57649bab3d8a",
  CellID->233229007],
 Cell[CellGroupData[{
-Cell[97437, 2393, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"7fae9970-dc68-e245-9f46-8994f5ee5141",
+Cell[97645, 2397, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"7fae9970-dc68-e245-9f46-8994f5ee5141",
  CellID->631233377],
-Cell[97682, 2400, 982, 19, 55, "ExampleText",ExpressionUUID->"7d2792ed-a50c-dc42-b7cf-2eebc24cfb54",
+Cell[97890, 2404, 982, 19, 55, "ExampleText",ExpressionUUID->"7d2792ed-a50c-dc42-b7cf-2eebc24cfb54",
  CellID->293180495],
-Cell[98667, 2421, 1000, 21, 60, "Input",ExpressionUUID->"721a1c35-bfb5-0948-bee2-ceebc38af976",
+Cell[98875, 2425, 1000, 21, 60, "Input",ExpressionUUID->"721a1c35-bfb5-0948-bee2-ceebc38af976",
  CellID->272350353],
 Cell[CellGroupData[{
-Cell[99692, 2446, 560, 13, 25, "Input",ExpressionUUID->"f5eef431-c9c4-9e46-831b-8a35c8a2687d",
+Cell[99900, 2450, 560, 13, 25, "Input",ExpressionUUID->"f5eef431-c9c4-9e46-831b-8a35c8a2687d",
  CellID->160919502],
-Cell[100255, 2461, 1955, 58, 59, "Output",ExpressionUUID->"43fa3a2f-af06-4e4e-ad6f-5ece44240063",
+Cell[100463, 2465, 1955, 58, 59, "Output",ExpressionUUID->"43fa3a2f-af06-4e4e-ad6f-5ece44240063",
  CellID->6363342]
 }, Open  ]],
-Cell[102225, 2522, 1153, 27, 60, "Input",ExpressionUUID->"483ecfc5-709b-8146-8dd0-098ca38a4797",
+Cell[102433, 2526, 1153, 27, 60, "Input",ExpressionUUID->"483ecfc5-709b-8146-8dd0-098ca38a4797",
  CellID->102614535],
 Cell[CellGroupData[{
-Cell[103403, 2553, 1048, 23, 77, "Input",ExpressionUUID->"6fd7a3ab-5bae-dd4d-9f73-aef3ac7c4285",
+Cell[103611, 2557, 1048, 23, 77, "Input",ExpressionUUID->"6fd7a3ab-5bae-dd4d-9f73-aef3ac7c4285",
  CellID->128440207],
-Cell[104454, 2578, 1684, 44, 63, "Output",ExpressionUUID->"2b67ed65-a4c7-b040-9cd9-ec60e20e40d2",
+Cell[104662, 2582, 1684, 44, 63, "Output",ExpressionUUID->"2b67ed65-a4c7-b040-9cd9-ec60e20e40d2",
  CellID->90272515]
 }, Open  ]],
-Cell[106153, 2625, 1333, 26, 77, "Input",ExpressionUUID->"e9d4adb0-50e5-924f-8e3e-6b7e5ea18180",
+Cell[106361, 2629, 1333, 26, 77, "Input",ExpressionUUID->"e9d4adb0-50e5-924f-8e3e-6b7e5ea18180",
  CellID->293997694]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
-Cell[107525, 2656, 264, 5, 32, "ExampleSection",ExpressionUUID->"c3540bf7-4f16-c642-a969-4ed7094638b3",
+Cell[107733, 2660, 264, 5, 32, "ExampleSection",ExpressionUUID->"c3540bf7-4f16-c642-a969-4ed7094638b3",
  CellID->112538656],
 Cell[CellGroupData[{
-Cell[107814, 2665, 243, 5, 20, "ExampleSection",ExpressionUUID->"48157590-5f28-1c47-b312-e61b33053c9b",
+Cell[108022, 2669, 243, 5, 20, "ExampleSection",ExpressionUUID->"48157590-5f28-1c47-b312-e61b33053c9b",
  CellID->476698288],
 Cell[CellGroupData[{
-Cell[108082, 2674, 317, 6, 23, "ExampleSubsection",ExpressionUUID->"451e5695-341a-c546-a778-98db479c45a9",
+Cell[108290, 2678, 317, 6, 23, "ExampleSubsection",ExpressionUUID->"451e5695-341a-c546-a778-98db479c45a9",
  CellID->200887691],
-Cell[108402, 2682, 276, 5, 23, "ExampleText",ExpressionUUID->"ccdbb751-605f-4445-a640-a25ca2709b72",
+Cell[108610, 2686, 276, 5, 23, "ExampleText",ExpressionUUID->"ccdbb751-605f-4445-a640-a25ca2709b72",
  CellID->654805157],
 Cell[CellGroupData[{
-Cell[108703, 2691, 2403, 56, 165, "Input",ExpressionUUID->"5ae1ea12-31b6-a34d-b277-c8e18ed2b10b",
+Cell[108911, 2695, 2403, 56, 165, "Input",ExpressionUUID->"5ae1ea12-31b6-a34d-b277-c8e18ed2b10b",
  CellID->1148403],
-Cell[111109, 2749, 828, 17, 24, "Output",ExpressionUUID->"b1bc5949-29ec-f243-a200-dbc171b8e13c",
+Cell[111317, 2753, 828, 17, 24, "Output",ExpressionUUID->"b1bc5949-29ec-f243-a200-dbc171b8e13c",
  CellID->259030309]
 }, Open  ]],
-Cell[111952, 2769, 754, 15, 39, "ExampleText",ExpressionUUID->"cfb008d8-df29-0b45-8346-1d6404a3be97",
+Cell[112160, 2773, 754, 15, 39, "ExampleText",ExpressionUUID->"cfb008d8-df29-0b45-8346-1d6404a3be97",
  CellID->8011592],
-Cell[112709, 2786, 1370, 35, 39, "ExampleText",ExpressionUUID->"d4255562-a5f7-0f4a-af7f-f6cd3b92ca28",
+Cell[112917, 2790, 1370, 35, 39, "ExampleText",ExpressionUUID->"d4255562-a5f7-0f4a-af7f-f6cd3b92ca28",
  CellID->641512217]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[114116, 2826, 379, 7, 23, "ExampleSubsection",ExpressionUUID->"0e375e75-e1de-2c47-a1c0-f7a50b70a9ca",
+Cell[114324, 2830, 379, 7, 23, "ExampleSubsection",ExpressionUUID->"0e375e75-e1de-2c47-a1c0-f7a50b70a9ca",
  CellID->1036996805],
-Cell[114498, 2835, 1165, 29, 39, "ExampleText",ExpressionUUID->"558e6c8a-e58a-644a-88f3-9751d9d9522a",
+Cell[114706, 2839, 1165, 29, 39, "ExampleText",ExpressionUUID->"558e6c8a-e58a-644a-88f3-9751d9d9522a",
  CellID->1975506230],
-Cell[115666, 2866, 609, 11, 25, "Input",ExpressionUUID->"380a173b-5e67-7940-aa26-27c4fc9c0549",
+Cell[115874, 2870, 609, 11, 25, "Input",ExpressionUUID->"380a173b-5e67-7940-aa26-27c4fc9c0549",
  CellID->88541343],
 Cell[CellGroupData[{
-Cell[116300, 2881, 551, 12, 42, "Input",ExpressionUUID->"c017836a-e98a-5240-92f7-4b4bbddc50df",
+Cell[116508, 2885, 551, 12, 42, "Input",ExpressionUUID->"c017836a-e98a-5240-92f7-4b4bbddc50df",
  CellID->150127483],
-Cell[116854, 2895, 8498, 176, 50, "Output",ExpressionUUID->"5e3970ac-1c3d-1748-a69c-7f5e303c139e",
+Cell[117062, 2899, 8498, 176, 50, "Output",ExpressionUUID->"5e3970ac-1c3d-1748-a69c-7f5e303c139e",
  CellID->59323161]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[125389, 3076, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"d6917866-9ad9-5542-b0ed-240d114110d9",
+Cell[125597, 3080, 242, 5, 16, "ExampleDelimiter",ExpressionUUID->"d6917866-9ad9-5542-b0ed-240d114110d9",
  CellID->117913872],
-Cell[125634, 3083, 1220, 31, 39, "ExampleText",ExpressionUUID->"a7353174-267f-1347-adbc-3cd9cd8a782d",
+Cell[125842, 3087, 1220, 31, 39, "ExampleText",ExpressionUUID->"a7353174-267f-1347-adbc-3cd9cd8a782d",
  CellID->77617597],
-Cell[126857, 3116, 802, 16, 42, "Input",ExpressionUUID->"60dd7b09-9a16-3d48-b3ac-607ede755324",
+Cell[127065, 3120, 802, 16, 42, "Input",ExpressionUUID->"60dd7b09-9a16-3d48-b3ac-607ede755324",
  CellID->111045181],
 Cell[CellGroupData[{
-Cell[127684, 3136, 739, 16, 42, "Input",ExpressionUUID->"c74ad2dc-f06e-ac49-a1bd-83b77f67cac2",
+Cell[127892, 3140, 739, 16, 42, "Input",ExpressionUUID->"c74ad2dc-f06e-ac49-a1bd-83b77f67cac2",
  CellID->146570750],
-Cell[128426, 3154, 11367, 231, 50, "Output",ExpressionUUID->"9e022a2e-af24-9349-af27-5a344d8f2b85",
+Cell[128634, 3158, 11367, 231, 50, "Output",ExpressionUUID->"9e022a2e-af24-9349-af27-5a344d8f2b85",
  CellID->213302025]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
-Cell[139844, 3391, 248, 5, 32, "ExampleSection",ExpressionUUID->"206cc408-b3fa-7e40-9802-13411716b1ae",
+Cell[140052, 3395, 248, 5, 32, "ExampleSection",ExpressionUUID->"206cc408-b3fa-7e40-9802-13411716b1ae",
  CellID->466091341],
 Cell[CellGroupData[{
-Cell[140117, 3400, 258, 5, 20, "ExampleSection",ExpressionUUID->"4b5afd69-30b0-f549-a027-fda2dd3b83dc",
+Cell[140325, 3404, 258, 5, 20, "ExampleSection",ExpressionUUID->"4b5afd69-30b0-f549-a027-fda2dd3b83dc",
  CellID->113613961],
 Cell[CellGroupData[{
-Cell[140400, 3409, 767, 14, 23, "ExampleSubsection",ExpressionUUID->"998b3398-46d9-a441-93a4-7718f68d2e53",
+Cell[140608, 3413, 767, 14, 23, "ExampleSubsection",ExpressionUUID->"998b3398-46d9-a441-93a4-7718f68d2e53",
  CellID->296669070],
-Cell[141170, 3425, 1703, 26, 55, "ExampleText",ExpressionUUID->"7fae03ca-b5ec-1445-82d3-872a8360a200",
+Cell[141378, 3429, 1703, 26, 55, "ExampleText",ExpressionUUID->"7fae03ca-b5ec-1445-82d3-872a8360a200",
  CellID->105689035],
-Cell[142876, 3453, 1543, 26, 39, "ExampleText",ExpressionUUID->"f0c703c0-675d-604c-b432-3e835efa8bb9",
+Cell[143084, 3457, 1543, 26, 39, "ExampleText",ExpressionUUID->"f0c703c0-675d-604c-b432-3e835efa8bb9",
  CellID->709734105],
-Cell[144422, 3481, 1492, 28, 71, "ExampleText",ExpressionUUID->"e1347469-3698-e04d-b3cd-80a0661f52d5",
+Cell[144630, 3485, 1492, 28, 71, "ExampleText",ExpressionUUID->"e1347469-3698-e04d-b3cd-80a0661f52d5",
  CellID->105347582],
-Cell[145917, 3511, 2507, 56, 158, "Input",ExpressionUUID->"6905becd-107c-0c40-a828-6d33a66536e2",
+Cell[146125, 3515, 2507, 56, 158, "Input",ExpressionUUID->"6905becd-107c-0c40-a828-6d33a66536e2",
  CellID->448289478],
-Cell[148427, 3569, 1062, 16, 55, "ExampleText",ExpressionUUID->"b900a028-a822-464c-b723-e8bfc1d1476e",
+Cell[148635, 3573, 1062, 16, 55, "ExampleText",ExpressionUUID->"b900a028-a822-464c-b723-e8bfc1d1476e",
  CellID->135010306],
-Cell[149492, 3587, 1350, 21, 55, "ExampleText",ExpressionUUID->"e541d214-04a7-bb47-af31-cfed6716a9fe",
+Cell[149700, 3591, 1350, 21, 55, "ExampleText",ExpressionUUID->"e541d214-04a7-bb47-af31-cfed6716a9fe",
  CellID->359104851],
 Cell[CellGroupData[{
-Cell[150867, 3612, 241, 5, 16, "ExampleDelimiter",ExpressionUUID->"90e3572b-3bc2-954e-acdf-2c2209c4376d",
+Cell[151075, 3616, 241, 5, 16, "ExampleDelimiter",ExpressionUUID->"90e3572b-3bc2-954e-acdf-2c2209c4376d",
  CellID->41691713],
-Cell[151111, 3619, 1920, 29, 71, "ExampleText",ExpressionUUID->"7879bff2-3886-2a43-9c05-3019887669c4",
+Cell[151319, 3623, 1920, 29, 71, "ExampleText",ExpressionUUID->"7879bff2-3886-2a43-9c05-3019887669c4",
  CellID->626781485],
-Cell[153034, 3650, 1961, 35, 55, "ExampleText",ExpressionUUID->"ddc09895-8ca9-8f42-8593-3dfa322b150c",
+Cell[153242, 3654, 1961, 35, 55, "ExampleText",ExpressionUUID->"ddc09895-8ca9-8f42-8593-3dfa322b150c",
  CellID->21247980],
-Cell[154998, 3687, 1974, 39, 87, "ExampleText",ExpressionUUID->"06029ee0-0624-264a-a3b9-4e23ea9b1bda",
+Cell[155206, 3691, 1974, 39, 87, "ExampleText",ExpressionUUID->"06029ee0-0624-264a-a3b9-4e23ea9b1bda",
  CellID->85481949],
-Cell[156975, 3728, 1009, 19, 42, "Input",ExpressionUUID->"fc0bec1d-c824-994c-8b82-8ed62b5098f8",
+Cell[157183, 3732, 1009, 19, 42, "Input",ExpressionUUID->"fc0bec1d-c824-994c-8b82-8ed62b5098f8",
  CellID->219430595],
-Cell[157987, 3749, 1942, 57, 222, "Input",ExpressionUUID->"0007b8f0-acb1-e04c-a6a7-76f76156aad4",
+Cell[158195, 3753, 1942, 57, 222, "Input",ExpressionUUID->"0007b8f0-acb1-e04c-a6a7-76f76156aad4",
  CellID->676015994],
-Cell[159932, 3808, 1062, 16, 55, "ExampleText",ExpressionUUID->"6b99138a-4076-cf45-a631-dc753e98a605",
+Cell[160140, 3812, 1062, 16, 55, "ExampleText",ExpressionUUID->"6b99138a-4076-cf45-a631-dc753e98a605",
  CellID->397014181],
-Cell[160997, 3826, 1527, 25, 55, "ExampleText",ExpressionUUID->"c4d37578-6565-334c-b1fa-0d179c17ecf1",
+Cell[161205, 3830, 1527, 25, 55, "ExampleText",ExpressionUUID->"c4d37578-6565-334c-b1fa-0d179c17ecf1",
  CellID->179261880]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
-Cell[162563, 3856, 251, 5, 32, "ExampleSection",ExpressionUUID->"4136bfca-ccae-4543-a89e-4ab36f7c6c92",
+Cell[162771, 3860, 251, 5, 32, "ExampleSection",ExpressionUUID->"4136bfca-ccae-4543-a89e-4ab36f7c6c92",
  CellID->594336563],
-Cell[162817, 3863, 256, 5, 20, "ExampleSection",ExpressionUUID->"b4c36045-96ed-834c-b920-7ee3972a6426",
+Cell[163025, 3867, 256, 5, 20, "ExampleSection",ExpressionUUID->"b4c36045-96ed-834c-b920-7ee3972a6426",
  CellID->763924802],
-Cell[163076, 3870, 248, 5, 20, "ExampleSection",ExpressionUUID->"06f28036-9ba1-174d-8b77-006aea84e464",
+Cell[163284, 3874, 248, 5, 20, "ExampleSection",ExpressionUUID->"06f28036-9ba1-174d-8b77-006aea84e464",
  CellID->76990128]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[163361, 3880, 109, 1, 71, "MetadataSection",ExpressionUUID->"01514484-f4d3-1046-88ee-2933f6f10c3c",
+Cell[163569, 3884, 109, 1, 71, "MetadataSection",ExpressionUUID->"01514484-f4d3-1046-88ee-2933f6f10c3c",
  CellID->42901253],
-Cell[163473, 3883, 473, 12, 25, "History",ExpressionUUID->"b24f5e18-8dc2-7c42-9e60-5eb0c5a2f27f",
+Cell[163681, 3887, 473, 12, 25, "History",ExpressionUUID->"b24f5e18-8dc2-7c42-9e60-5eb0c5a2f27f",
  CellID->969934],
 Cell[CellGroupData[{
-Cell[163971, 3899, 484, 13, 20, "CategorizationSection",ExpressionUUID->"54061416-e7a9-2f4a-be70-40d9b092ffe3",
+Cell[164179, 3903, 484, 13, 20, "CategorizationSection",ExpressionUUID->"54061416-e7a9-2f4a-be70-40d9b092ffe3",
  CellID->155892578],
-Cell[164458, 3914, 134, 2, 35, "Categorization",ExpressionUUID->"d38e05c9-59d0-a44b-ad25-467dfb60ec55",
+Cell[164666, 3918, 134, 2, 35, "Categorization",ExpressionUUID->"d38e05c9-59d0-a44b-ad25-467dfb60ec55",
  CellID->379313778],
-Cell[164595, 3918, 159, 2, 35, "Categorization",ExpressionUUID->"f8011cf6-d3ee-0149-a640-c6d486bf3660",
+Cell[164803, 3922, 159, 2, 35, "Categorization",ExpressionUUID->"f8011cf6-d3ee-0149-a640-c6d486bf3660",
  CellID->123752965],
-Cell[164757, 3922, 156, 2, 35, "Categorization",ExpressionUUID->"c2aaec4f-b9fb-7c4e-ac7d-63c6d46998c8",
+Cell[164965, 3926, 156, 2, 35, "Categorization",ExpressionUUID->"c2aaec4f-b9fb-7c4e-ac7d-63c6d46998c8",
  CellID->207073079],
-Cell[164916, 3926, 355, 7, 35, "Categorization",ExpressionUUID->"ffab9e82-e6de-3843-8507-c30bd9940ae6",
+Cell[165124, 3930, 355, 7, 35, "Categorization",ExpressionUUID->"ffab9e82-e6de-3843-8507-c30bd9940ae6",
  CellID->485781109]
 }, Closed]],
 Cell[CellGroupData[{
-Cell[165308, 3938, 109, 1, 20, "KeywordsSection",ExpressionUUID->"9948f113-07ed-b749-a7c7-02455661517b",
+Cell[165516, 3942, 109, 1, 20, "KeywordsSection",ExpressionUUID->"9948f113-07ed-b749-a7c7-02455661517b",
  CellID->55111812],
-Cell[165420, 3941, 98, 1, 70, "Keywords",ExpressionUUID->"13a5388c-964d-e948-88a8-f2bed6c00cae",
+Cell[165628, 3945, 98, 1, 70, "Keywords",ExpressionUUID->"13a5388c-964d-e948-88a8-f2bed6c00cae",
  CellID->78694749]
 }, Closed]],
 Cell[CellGroupData[{
-Cell[165555, 3947, 119, 1, 20, "TemplatesSection",ExpressionUUID->"6439de18-e57c-d548-bfa1-0f1cff993b74",
+Cell[165763, 3951, 119, 1, 20, "TemplatesSection",ExpressionUUID->"6439de18-e57c-d548-bfa1-0f1cff993b74",
  CellID->272215535],
-Cell[165677, 3950, 148, 2, 70, "Template",ExpressionUUID->"9a729cf7-1198-3c4b-b13a-f189371bdae6",
+Cell[165885, 3954, 148, 2, 70, "Template",ExpressionUUID->"9a729cf7-1198-3c4b-b13a-f189371bdae6",
  CellID->476199561],
-Cell[165828, 3954, 136, 2, 70, "Template",ExpressionUUID->"4d280ee1-1eaf-df45-bf64-789cd00641a2",
+Cell[166036, 3958, 136, 2, 70, "Template",ExpressionUUID->"4d280ee1-1eaf-df45-bf64-789cd00641a2",
  CellID->39443153],
-Cell[165967, 3958, 135, 2, 70, "Template",ExpressionUUID->"fe3509c5-ddbf-f84d-a38d-d2582ffef23c",
+Cell[166175, 3962, 135, 2, 70, "Template",ExpressionUUID->"fe3509c5-ddbf-f84d-a38d-d2582ffef23c",
  CellID->140411135],
-Cell[166105, 3962, 135, 2, 70, "Template",ExpressionUUID->"e2d612c8-c48e-c943-824b-d02a310bb682",
+Cell[166313, 3966, 135, 2, 70, "Template",ExpressionUUID->"e2d612c8-c48e-c943-824b-d02a310bb682",
  CellID->8216975]
 }, Closed]]
 }, Open  ]]


### PR DESCRIPTION
The user input for the construction of non-reciprocal hyperbolic lattice models with multiple orbitals per site is not explained in detail. This PR clarifies the used conventions through a general two-orbital {p, q}-lattice model with two sites per unit cell, together with an explicit example with symbolic coupling constants.